### PR TITLE
Static Content Pages (Rules, Disclosure, Powers, Bill Process, Elections, How to Apply, Budget Process)

### DIFF
--- a/frontend/src/app/about/bill-process/page.tsx
+++ b/frontend/src/app/about/bill-process/page.tsx
@@ -1,8 +1,5 @@
+import StaticPage from "@/components/StaticPage";
+
 export default function BillProcessPage() {
-  return (
-    <section>
-      <h1>Bill Process</h1>
-      <p>This page will explain the bill process from proposal to final action.</p>
-    </section>
-  );
+  return <StaticPage slug="how-a-bill-becomes-law" />;
 }

--- a/frontend/src/app/about/powers/page.tsx
+++ b/frontend/src/app/about/powers/page.tsx
@@ -1,8 +1,5 @@
+import StaticPage from "@/components/StaticPage";
+
 export default function PowersPage() {
-  return (
-    <section>
-      <h1>Legislative Powers</h1>
-      <p>This page will contain information about the powers of the Senate.</p>
-    </section>
-  );
+  return <StaticPage slug="powers-of-senate" />;
 }

--- a/frontend/src/app/elections/page.tsx
+++ b/frontend/src/app/elections/page.tsx
@@ -1,8 +1,5 @@
+import StaticPage from "@/components/StaticPage";
+
 export default function ElectionsPage() {
-  return (
-    <section>
-      <h1>Elections</h1>
-      <p>This page will contain information about Senate elections.</p>
-    </section>
-  );
+  return <StaticPage slug="elections" />;
 }

--- a/frontend/src/app/funding/apply/page.tsx
+++ b/frontend/src/app/funding/apply/page.tsx
@@ -1,8 +1,5 @@
+import StaticPage from "@/components/StaticPage";
+
 export default function FundingApplyPage() {
-  return (
-    <section>
-      <h1>Apply for Funding</h1>
-      <p>This page will explain how to apply for funding.</p>
-    </section>
-  );
+  return <StaticPage slug="how-to-apply" />;
 }

--- a/frontend/src/app/funding/budget-process/page.tsx
+++ b/frontend/src/app/funding/budget-process/page.tsx
@@ -1,8 +1,5 @@
+import StaticPage from "@/components/StaticPage";
+
 export default function FundingBudgetProcessPage() {
-  return (
-    <section>
-      <h1>Budget Process</h1>
-      <p>This page will describe the student government budget process.</p>
-    </section>
-  );
+  return <StaticPage slug="budget-process" />;
 }

--- a/frontend/src/app/legislation/disclosure/page.tsx
+++ b/frontend/src/app/legislation/disclosure/page.tsx
@@ -1,8 +1,5 @@
+import StaticPage from "@/components/StaticPage";
+
 export default function DisclosurePage() {
-  return (
-    <section>
-      <h1>Legislation Disclosure</h1>
-      <p>This page will contain disclosure information for legislation.</p>
-    </section>
-  );
+  return <StaticPage slug="public-disclosure" />;
 }

--- a/frontend/src/app/legislation/rules/page.tsx
+++ b/frontend/src/app/legislation/rules/page.tsx
@@ -1,8 +1,5 @@
+import StaticPage from "@/components/StaticPage";
+
 export default function RulesPage() {
-  return (
-    <section>
-      <h1>Legislation Rules</h1>
-      <p>This page will contain information about Senate legislation rules.</p>
-    </section>
-  );
+  return <StaticPage slug="senate-rules" />;
 }

--- a/frontend/src/components/StaticPage.tsx
+++ b/frontend/src/components/StaticPage.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { ApiError, getStaticPage } from "@/lib/api";
+import type { StaticPage as StaticPageContent } from "@/types";
+
+interface StaticPageProps {
+  slug: string;
+}
+
+const placeholderTitle = "Content Coming Soon";
+const placeholderBody =
+  "This page is being prepared. Please check back soon for the latest information.";
+
+export default function StaticPage({ slug }: StaticPageProps) {
+  const [page, setPage] = useState<StaticPageContent | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadPage = async () => {
+      setIsLoading(true);
+      setErrorMessage(null);
+
+      try {
+        const data = await getStaticPage(slug);
+        if (!isMounted) {
+          return;
+        }
+        setPage(data);
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+
+        if (error instanceof ApiError && error.status === 404) {
+          setErrorMessage(
+            "This page does not have published content yet. Showing placeholder text for now.",
+          );
+        } else {
+          setErrorMessage(
+            "Unable to load page content right now. Showing placeholder text until the backend is ready.",
+          );
+        }
+        setPage(null);
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadPage();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [slug]);
+
+  if (isLoading) {
+    return (
+      <section>
+        <h1>Loading...</h1>
+        <p>Fetching page content.</p>
+      </section>
+    );
+  }
+
+  const title = page?.title || placeholderTitle;
+  const body = page?.body || `<p>${placeholderBody}</p>`;
+
+  return (
+    <section>
+      <h1>{title}</h1>
+      {errorMessage ? <p>{errorMessage}</p> : null}
+      <div
+        // TODO: Add server-side sanitization before rendering user-managed HTML.
+        dangerouslySetInnerHTML={{ __html: body }}
+      />
+    </section>
+  );
+}


### PR DESCRIPTION
Seven pages share the same pattern: fetch content from the StaticPageContent API and render it. Building them all at once avoids repetition and creates a reusable pattern.

Changes:

- Added a reusable static content component at `StaticPage.tsx`
  - Fetches by slug via existing getStaticPage API helper.
  - Shows loading state.
  - Handles error states.
  - Falls back to placeholder title/body when content is missing or backend is unavailable.
  - Renders CMS HTML with dangerouslySetInnerHTML, with a TODO note for sanitization.

Closes #49 
