### PR TITLE
TypeScript Types + API Client #9

### DIFF
--- a/frontend/src/app/senators/previous-leadership/page.tsx
+++ b/frontend/src/app/senators/previous-leadership/page.tsx
@@ -1,5 +1,6 @@
+export const dynamic = "force-dynamic";
 
-import { getLeadership } from "@/lib/api" // adjust path as needed
+import { getLeadership } from "@/lib/api"
 import { Leadership } from "@/types"
 
 // unused since seems unnecessary with current api setup but was in important notes


### PR DESCRIPTION
Previous Leadership shows historical senate officers grouped by session. It's a simple display page that reuses the Leadership type and API call with a session filter.

Changes:

- I filled out the PreviousLeadershipPage in order to display the leaders, received from the getLeadership() api call
- I implemented a groupBySession(), and respective frontend map, function for displaying leaders by session
- I added a formatSession() in order to allow for compatible session number displays (i.e. 1 has st, while 11 has th)

