### PR TITLE
Previous Leadership Page UI #45

### DIFF
--- a/frontend/src/app/senators/previous-leadership/page.tsx
+++ b/frontend/src/app/senators/previous-leadership/page.tsx
@@ -28,7 +28,7 @@ function groupBySession(leaders: Leadership[]) {
 function formatSession(n: number) {
   const s = ["th", "st", "nd", "rd"]
   const v = n % 100
-  return `${n}${s[(v - 20) % 10] || s[v] || s[0]} Session`
+  return `${n}${s[(v - 20) % 10] || s[v] || s[0]} Senate`
 }
 
 export default async function PreviousLeadershipPage() {


### PR DESCRIPTION
Previous Leadership shows historical senate officers grouped by session. It's a simple display page that reuses the Leadership type and API call with a session filter.

Changes:

 - I filled out the PreviousLeadershipPage in order to display the leaders, received from the getLeadership() api call
 - I implemented a groupBySession(), and respective frontend map, function for displaying leaders by session
 - I added a formatSession() in order to allow for compatible session number displays (i.e. 1 has st, while 11 has th)

Closes #45 
