### PR TITLE
Header Navigation Route Mismatch Bugfix

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 """FastAPI application entry point"""
 
+from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -21,6 +22,8 @@ from app.routers import (
 )
 from app.routers.admin import committees as admin_committees
 from app.routers.admin import news as admin_news
+
+load_dotenv()
 
 app = FastAPI(
     title="Senate API",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,6 @@
+# Environment variables
+python-dotenv==1.0.1
+
 # Pydantic
 pydantic[email]==2.12.5
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -41,15 +41,15 @@ const aboutItems = [
   { title: "Staff", href: "/about/staff" },
   { title: "Powers of the Senate", href: "/about/powers" },
   {
-    title: "How a Bill Becomes a Law",
-    href: "/about/how-a-bill-becomes-a-law",
+    title: "Bill Process",
+    href: "/about/bill-process",
   },
-  { title: "Elections", href: "/about/elections" },
+  { title: "Elections", href: "/elections" },
 ];
 
 const fundingItems = [
   { title: "How to Apply", href: "/funding/apply" },
-  { title: "Budget Process", href: "/funding/budget-process" },
+  { title: "Budget", href: "/funding/budget" },
   { title: "Where Does My Money Go?", href: "/funding/where-does-money-go" },
 ];
 


### PR DESCRIPTION
Several navigation links route to non-existent paths even though the destination pages already exist. This is a user-facing bug independent of future page buildout.

Changes:

- Fixed Header links to right routes
- Added dotenv to backend main to properly load .env

Closes #83 
