### PR TITLE
Leadership API Client Endpoint Normalization

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,9 @@
 import os
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 JWT_SECRET = os.getenv("JWT_SECRET")
 if not JWT_SECRET:
     raise RuntimeError("JWT_SECRET environment variable is required")

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -83,6 +83,19 @@ function normalizeEndpoint(endpoint: string): string {
   return endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
 }
 
+function buildLeadershipEndpoint(session?: number): string {
+  const query = createQueryString({ session_number: session });
+  const endpoint = `/api/leadership${query}`;
+
+  // Guard against accidental regressions like /api/leadership/?session_number=...
+  console.assert(
+    !endpoint.includes("/?"),
+    "Leadership endpoint should not include a trailing slash before query params",
+  );
+
+  return endpoint;
+}
+
 async function extractErrorDetails(response: Response): Promise<unknown> {
   const contentType = response.headers.get("content-type") || "";
   if (contentType.includes("application/json")) {
@@ -158,8 +171,7 @@ export async function getSenatorById(id: string | number): Promise<Senator> {
 }
 
 export async function getLeadership(session?: number): Promise<Leadership[]> {
-  const query = createQueryString({ session_number: session });
-  return fetchAPI<Leadership[]>(`/api/leadership/${query}`);
+  return fetchAPI<Leadership[]>(buildLeadershipEndpoint(session));
 }
 
 export async function getCommittees(): Promise<Committee[]> {


### PR DESCRIPTION
`getLeadership()` currently constructs an endpoint with a trailing slash before query params. This is brittle and inconsistent with the rest of the API client.

Changes:

- Leadership endpoint normalized to /api/leadership
- dotenv import fixed

Closes #84 
