### PR TITLE
Leadership Default Session Behavior

### DIFF
--- a/backend/app/routers/leadership.py
+++ b/backend/app/routers/leadership.py
@@ -17,7 +17,13 @@ def _current_session(db: Session) -> int:
 
 @router.get("/", response_model=list[LeadershipDTO])
 def get_leadership(session_number: int | None = None, db: Session = Depends(get_db)):
+    """Return leadership rows for the requested session.
 
+    If ``session_number`` is omitted, the API defaults to the latest session
+    present in the leadership table. The endpoint returns every row for that
+    session; active vs inactive status is surfaced through ``is_current`` on
+    each item instead of being filtered out here.
+    """
     target_session = session_number if session_number is not None else _current_session(db)
     query = db.query(Leadership).filter(Leadership.session_number == target_session)
 

--- a/backend/tests/routers/conftest.py
+++ b/backend/tests/routers/conftest.py
@@ -127,6 +127,9 @@ def seeded_committees(test_db):
 @pytest.fixture
 def seeded_leadership(test_db):
     """Seed test data for leadership."""
+    test_db.query(Leadership).delete()
+    test_db.commit()
+
     l1 = Leadership(
         title="Speaker",
         first_name="John",
@@ -154,11 +157,20 @@ def seeded_leadership(test_db):
         is_active=True,
         session_number=2025,
     )
+    l4 = Leadership(
+        title="Parliamentarian",
+        first_name="Maya",
+        last_name="Nguyen",
+        email="maya@example.com",
+        headshot_url=None,
+        is_active=False,
+        session_number=2025,
+    )
 
-    test_db.add_all([l1, l2, l3])
+    test_db.add_all([l1, l2, l3, l4])
     test_db.commit()
 
-    yield {"records": [l1, l2, l3]}
+    yield {"records": [l1, l2, l3, l4]}
 
 @pytest.fixture(scope="module")
 def seeded_admins(test_db):

--- a/backend/tests/routers/test_leadership.py
+++ b/backend/tests/routers/test_leadership.py
@@ -2,16 +2,24 @@
 
 
 # --- Tests ---
-def test_get_all_active_leadership(client, seeded_leadership):
+def test_get_current_session_leadership(client, seeded_leadership):
     response = client.get("/api/leadership/")
     assert response.status_code == 200
     data = response.json()
 
-    # Only active records should be returned
+    # Defaulting should return the current session, including inactive rows.
     titles = [leader["title"] for leader in data]
     assert "Speaker" in titles
     assert "Whip" in titles
+    assert "Parliamentarian" in titles
     assert "Minority Leader" not in titles
+
+    parliamentarian = next(leader for leader in data if leader["title"] == "Parliamentarian")
+    assert parliamentarian["session_number"] == 2025
+    assert parliamentarian["is_current"] is False
+
+    speaker = next(leader for leader in data if leader["title"] == "Speaker")
+    assert speaker["is_current"] is True
 
 
 def test_get_leadership_by_session_number(client, seeded_leadership):
@@ -19,10 +27,23 @@ def test_get_leadership_by_session_number(client, seeded_leadership):
     assert response.status_code == 200
     data = response.json()
 
-    # Should return only records with session_number=2025
+    # Explicit session filters should return all records for that session.
     assert all(leader["session_number"] == 2025 for leader in data)
     titles = [leader["title"] for leader in data]
-    assert set(titles) == {"Speaker", "Whip"}
+    assert set(titles) == {"Speaker", "Whip", "Parliamentarian"}
+
+    inactive = next(leader for leader in data if leader["title"] == "Parliamentarian")
+    assert inactive["is_current"] is False
+
+
+def test_get_leadership_by_previous_session(client, seeded_leadership):
+    response = client.get("/api/leadership/?session_number=2023")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data) == 1
+    assert data[0]["title"] == "Minority Leader"
+    assert data[0]["is_current"] is False
 
 
 def test_get_leadership_by_id_success(client, seeded_leadership):

--- a/frontend/src/app/senators/previous-leadership/page.tsx
+++ b/frontend/src/app/senators/previous-leadership/page.tsx
@@ -1,76 +1,19 @@
-export const dynamic = "force-dynamic";
+import Link from "next/link";
 
-import { getLeadership } from "@/lib/api"
-import { Leadership } from "@/types"
-
-// unused since seems unnecessary with current api setup but was in important notes
-// async function fetchAllLeadership(): Promise<Leader[]> {
-//   // assumed some mock sessions here, if needed can just use a api call to get available ones
-//   const sessions = Array.from({ length: 20 }, (_, i) => 100 + i)
-
-//   const results = await Promise.all(
-//     sessions.map(async (session) => await getLeadership(session))
-//   )
-
-//   return results.flat()
-// }
-
-function groupBySession(leaders: Leadership[]) {
-  return leaders.reduce<Record<number, Leadership[]>>((acc, leader) => {
-    if (!acc[leader.session_number]) {
-      acc[leader.session_number] = []
-    }
-    acc[leader.session_number].push(leader)
-    return acc
-  }, {})
-}
-
-function formatSession(n: number) {
-  const s = ["th", "st", "nd", "rd"]
-  const v = n % 100
-  return `${n}${s[(v - 20) % 10] || s[v] || s[0]} Senate`
-}
-
-export default async function PreviousLeadershipPage() {
-  // Look above for additional documentation
-  // const leaders = await fetchAllLeadership()
-  const leaders = await getLeadership()
-  const grouped = groupBySession(leaders)
-
-  // Sort sessions descending (most recent first)
-  const sortedSessions = Object.keys(grouped)
-    .map(Number)
-    .sort((a, b) => b - a)
-
+export default function PreviousLeadershipPage() {
   return (
-    <div className="max-w-5xl mx-auto px-6 py-10">
-      <h1 className="text-3xl font-bold mb-8">Previous Senate Leadership</h1>
-
-      <div className="space-y-10">
-        {sortedSessions.map((session) => (
-          <div key={session}>
-            <h2 className="text-xl font-semibold mb-4">
-              {formatSession(session)}
-            </h2>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-              {grouped[session].map((leader) => (
-                <div
-                  key={leader.id}
-                  className="border rounded-xl p-4 shadow-sm hover:shadow-md transition"
-                >
-                  <div className="text-base font-medium">
-                    {leader.first_name} {leader.last_name}
-                  </div>
-                  <div className="text-sm text-gray-600">
-                    {leader.title}
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
+    <div className="max-w-3xl mx-auto px-6 py-12">
+      <h1 className="text-3xl font-bold mb-4">Previous Senate Leadership</h1>
+      <p className="text-gray-700 mb-6">
+        Historical leadership records are not available yet. This page will show
+        archived sessions once the backend exposes that data.
+      </p>
+      <Link
+        href="/senators/leadership"
+        className="inline-flex items-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-50"
+      >
+        View current leadership
+      </Link>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
TDD requires leadership to default to the current session when no filter is provided. Behavior for active/inactive inclusion should be explicit and tested.

Changes:

- Normalized leadership API default session behavior
- Updated leadership tests
- Replaced misleading previous-leadership page with placeholder

Closes #85 
