### PR TITLE
Previous Leadership Historical Session Data Completeness

### DIFF
--- a/backend/app/routers/leadership.py
+++ b/backend/app/routers/leadership.py
@@ -37,6 +37,28 @@ def get_leadership(session_number: int | None = None, db: Session = Depends(get_
     return leadership
 
 
+@router.get("/sessions/all", response_model=list[LeadershipDTO])
+def get_all_leadership_sessions(db: Session = Depends(get_db)):
+    """Return all leadership records across all sessions, ordered by session
+    descending, then by title.
+
+    This endpoint is designed for the previous-leadership page to load
+    multi-session data reliably in a single API call.
+    """
+    query = db.query(Leadership).order_by(
+        Leadership.session_number.desc(), Leadership.title
+    )
+
+    leadership = query.all()
+
+    # dynamically add is_current based on is_active
+    for leader in leadership:
+        leader.is_current = leader.is_active
+        leader.photo_url = leader.headshot_url
+
+    return leadership
+
+
 @router.get("/{id}", response_model=LeadershipDTO)
 def get_leadership_by_id(id: int, db: Session = Depends(get_db)):
 

--- a/backend/tests/routers/test_leadership.py
+++ b/backend/tests/routers/test_leadership.py
@@ -46,6 +46,35 @@ def test_get_leadership_by_previous_session(client, seeded_leadership):
     assert data[0]["is_current"] is False
 
 
+def test_get_all_leadership_sessions(client, seeded_leadership):
+    """Test fetching all leadership records across all sessions."""
+    response = client.get("/api/leadership/sessions/all")
+    assert response.status_code == 200
+    data = response.json()
+
+    # Should return records from both 2025 and 2023 sessions
+    sessions = {leader["session_number"] for leader in data}
+    assert 2025 in sessions
+    assert 2023 in sessions
+
+    # Data should be ordered by session descending, then by title
+    # Check that 2025 records come before 2023 records
+    session_indices = [i for i, leader in enumerate(data) if leader["session_number"] == 2025]
+    if session_indices and not all(
+        leader["session_number"] == 2025 for leader in data[: session_indices[-1] + 1]
+    ):
+        # If there's mixed sessions, ensure 2025 comes first
+        first_2023_idx = next(
+            i for i, leader in enumerate(data) if leader["session_number"] == 2023
+        )
+        assert all(
+            leader["session_number"] == 2025 for leader in data[:first_2023_idx]
+        ), "Sessions should be ordered descending"
+
+    # Total count should match seeded data
+    assert len(data) == 4  # 3 from 2025 + 1 from 2023
+
+
 def test_get_leadership_by_id_success(client, seeded_leadership):
     leadership = seeded_leadership["records"][0]  # Speaker
     response = client.get(f"/api/leadership/{leadership.id}")

--- a/frontend/src/app/senators/previous-leadership/page.tsx
+++ b/frontend/src/app/senators/previous-leadership/page.tsx
@@ -1,19 +1,135 @@
+"use client";
+
 import Link from "next/link";
+import { useEffect, useState } from "react";
+
+interface LeadershipRecord {
+  id: number;
+  first_name: string;
+  last_name: string;
+  title: string;
+  session_number: number;
+  is_current: boolean;
+}
+
+interface GroupedBySession {
+  [session: number]: LeadershipRecord[];
+}
+
+async function fetchAllLeadership(): Promise<LeadershipRecord[]> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const response = await fetch(`${apiUrl}/api/leadership/sessions/all`);
+  if (!response.ok) {
+    throw new Error("Failed to fetch leadership data");
+  }
+  return response.json();
+}
+
+function getSessionName(sessionNumber: number): string {
+  const suffix =
+    sessionNumber % 100 >= 11 && sessionNumber % 100 <= 13
+      ? "th"
+      : {
+          1: "st",
+          2: "nd",
+          3: "rd",
+        }[sessionNumber % 10] || "th";
+  return `${sessionNumber}${suffix} Senate`;
+}
 
 export default function PreviousLeadershipPage() {
+  const [leadership, setLeadership] = useState<GroupedBySession>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        setIsLoading(true);
+        const data = await fetchAllLeadership();
+
+        // Group by session number, maintaining order by descending session
+        const grouped: GroupedBySession = {};
+        data.forEach((leader) => {
+          if (!grouped[leader.session_number]) {
+            grouped[leader.session_number] = [];
+          }
+          grouped[leader.session_number].push(leader);
+        });
+
+        setLeadership(grouped);
+        setError(null);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to load leadership data",
+        );
+        setLeadership({});
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadData();
+  }, []);
+
   return (
     <div className="max-w-3xl mx-auto px-6 py-12">
       <h1 className="text-3xl font-bold mb-4">Previous Senate Leadership</h1>
-      <p className="text-gray-700 mb-6">
-        Historical leadership records are not available yet. This page will show
-        archived sessions once the backend exposes that data.
-      </p>
-      <Link
-        href="/senators/leadership"
-        className="inline-flex items-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-50"
-      >
-        View current leadership
-      </Link>
+
+      {isLoading && (
+        <p className="text-gray-700 mb-6">Loading leadership records...</p>
+      )}
+
+      {error && (
+        <div className="rounded-lg bg-red-50 p-4 mb-6">
+          <p className="text-red-700">Error: {error}</p>
+        </div>
+      )}
+
+      {!isLoading && Object.keys(leadership).length === 0 && !error && (
+        <p className="text-gray-700 mb-6">
+          No historical leadership records available yet.
+        </p>
+      )}
+
+      {!isLoading && Object.keys(leadership).length > 0 && (
+        <div className="space-y-8">
+          {Object.entries(leadership)
+            .sort(
+              ([sessionA], [sessionB]) => Number(sessionB) - Number(sessionA),
+            )
+            .map(([session, leaders]) => (
+              <div key={session}>
+                <h2 className="text-xl font-bold mb-4 text-blue-700">
+                  {getSessionName(Number(session))}
+                </h2>
+                <div className="space-y-3 pl-4 border-l-4 border-blue-200">
+                  {leaders
+                    .sort((a: LeadershipRecord, b: LeadershipRecord) =>
+                      a.title.localeCompare(b.title),
+                    )
+                    .map((leader: LeadershipRecord) => (
+                      <div key={leader.id} className="pb-2">
+                        <p className="font-semibold text-gray-900">
+                          {leader.first_name} {leader.last_name}
+                        </p>
+                        <p className="text-sm text-gray-600">{leader.title}</p>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            ))}
+        </div>
+      )}
+
+      <div className="mt-8 pt-6 border-t border-gray-200">
+        <Link
+          href="/senators/leadership"
+          className="inline-flex items-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-50"
+        >
+          View current leadership
+        </Link>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
The previous leadership page currently risks only showing current session data. TDD expects historical leadership grouped by session.

Changes:

- New backend endpoint for all leadership sessions
- Previous leadership page switched from placeholder to live grouped historical data view
- Tests for this new endpoint

Closes #86 