### PR TITLE
Admin Committee Management Page #95

### DIFF
--- a/backend/app/routers/admin/committees.py
+++ b/backend/app/routers/admin/committees.py
@@ -20,6 +20,21 @@ router = APIRouter(
 )
 
 
+@router.get("", response_model=list[CommitteeDTO])
+def list_committees(
+    db: Session = Depends(get_db),
+    _current_user: Admin = Depends(get_current_user),
+):
+    committees = (
+        db.query(Committee)
+        .options(selectinload(Committee.memberships).selectinload(CommitteeMembership.senator))
+        .order_by(Committee.name)
+        .all()
+    )
+
+    return [serialize_committee(committee) for committee in committees]
+
+
 def serialize_committee(committee: Committee) -> dict:
     members = []
     # If memberships are loaded

--- a/backend/tests/routers/test_admin_committees.py
+++ b/backend/tests/routers/test_admin_committees.py
@@ -47,6 +47,17 @@ def test_create_committee(admin_client, test_db):
     assert len(data["members"]) == 0
 
 
+def test_list_committees(admin_client, seeded_committees):
+    response = admin_client.get("/api/admin/committees")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    assert all("id" in committee for committee in data)
+    assert all("members" in committee for committee in data)
+
+
 def test_update_committee(admin_client, seeded_committees):
     committee = seeded_committees["committees"][0]
     response = admin_client.put(

--- a/frontend/src/app/admin/committees/page.tsx
+++ b/frontend/src/app/admin/committees/page.tsx
@@ -1,42 +1,80 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
-  createCommittee,
-  updateCommittee,
-  deleteCommittee,
   assignCommitteeMember,
+  createCommittee,
+  deleteCommittee,
+  getAdminCommittees,
   removeCommitteeMember,
+  updateCommittee,
 } from "@/lib/admin-api";
 import { getSenators } from "@/lib/api";
-import type { Committee, Senator } from "@/types";
+import type { Committee, CommitteeAssignment, Senator } from "@/types";
+import type { CreateCommittee } from "@/types/admin";
+import { Fragment, useEffect, useState } from "react";
 
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+interface CommitteeFormState {
+  name: string;
+  description: string;
+  chair_senator_id: string;
+  chair_name: string;
+  chair_email: string;
+  is_active: boolean;
+}
+
+function emptyCommitteeForm(): CommitteeFormState {
+  return {
+    name: "",
+    description: "",
+    chair_senator_id: "",
+    chair_name: "",
+    chair_email: "",
+    is_active: true,
+  };
+}
+
+function toCommitteePayload(form: CommitteeFormState): CreateCommittee {
+  return {
+    name: form.name.trim(),
+    description: form.description.trim(),
+    chair_senator_id: form.chair_senator_id
+      ? Number(form.chair_senator_id)
+      : null,
+    chair_name: form.chair_name.trim(),
+    chair_email: form.chair_email.trim(),
+    is_active: form.is_active,
+  };
+}
 
 export default function CommitteesPage() {
   const [committees, setCommittees] = useState<Committee[]>([]);
   const [senators, setSenators] = useState<Senator[]>([]);
   const [expanded, setExpanded] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    async function load() {
-      const [c, s] = await Promise.all([
-        fetch("/api/admin/committees").then((r) => r.json()),
-        getSenators(),
-      ]);
-      setCommittees(c);
-      setSenators(s);
+    async function load(): Promise<void> {
+      setIsLoading(true);
+      try {
+        const [adminCommittees, allSenators] = await Promise.all([
+          getAdminCommittees(),
+          getSenators(),
+        ]);
+        setCommittees(adminCommittees);
+        setSenators(allSenators);
+      } catch (error) {
+        console.error("Failed to load committees page data:", error);
+        alert("Failed to load committees.");
+      } finally {
+        setIsLoading(false);
+      }
     }
-    load();
+
+    void load();
   }, []);
 
-  function updateLocal(updated: Committee) {
+  function updateLocal(updated: Committee): void {
     setCommittees((prev) =>
       prev.map((c) => (c.id === updated.id ? updated : c)),
     );
@@ -49,57 +87,85 @@ export default function CommitteesPage() {
       <CommitteeForm
         senators={senators}
         onCreate={async (data) => {
-          const res = await createCommittee(data);
-          setCommittees((p) => [...p, res]);
+          const created = await createCommittee(data);
+          setCommittees((prev) => [...prev, created]);
         }}
       />
 
-      <div className="grid gap-4">
-        {committees.map((c) => (
-          <Card key={c.id}>
-            <CardHeader>
-              <CardTitle>{c.name}</CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Chair: {c.chair_name} •{" "}
-                {c.is_active ? "Active" : "Inactive"} •{" "}
-                {c.members.length} members
-              </p>
-            </CardHeader>
+      <div className="overflow-x-auto border rounded-md">
+        {isLoading && (
+          <p className="text-sm text-muted-foreground p-3">
+            Loading committees...
+          </p>
+        )}
 
-            <CardContent className="space-y-3">
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  onClick={() =>
-                    setExpanded(expanded === c.id ? null : c.id)
-                  }
-                >
-                  {expanded === c.id ? "Hide" : "Manage"}
-                </Button>
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="text-left p-3 font-medium">Name</th>
+              <th className="text-left p-3 font-medium">Chair</th>
+              <th className="text-left p-3 font-medium">Active</th>
+              <th className="text-left p-3 font-medium">Member Count</th>
+              <th className="text-left p-3 font-medium">Actions</th>
+            </tr>
+          </thead>
 
-                <Button
-                  variant="destructive"
-                  onClick={async () => {
-                    await deleteCommittee(c.id);
-                    setCommittees((p) =>
-                      p.filter((x) => x.id !== c.id),
-                    );
-                  }}
-                >
-                  Delete
-                </Button>
-              </div>
+          <tbody>
+            {committees.map((committee) => (
+              <Fragment key={committee.id}>
+                <tr className="border-t align-top">
+                  <td className="p-3">{committee.name}</td>
+                  <td className="p-3">{committee.chair_name}</td>
+                  <td className="p-3">{committee.is_active ? "Yes" : "No"}</td>
+                  <td className="p-3">{committee.members.length}</td>
+                  <td className="p-3">
+                    <div className="flex gap-2">
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          setExpanded(
+                            expanded === committee.id ? null : committee.id,
+                          )
+                        }
+                      >
+                        {expanded === committee.id ? "Hide" : "Manage"}
+                      </Button>
 
-              {expanded === c.id && (
-                <CommitteeDetail
-                  committee={c}
-                  senators={senators}
-                  onUpdate={updateLocal}
-                />
-              )}
-            </CardContent>
-          </Card>
-        ))}
+                      <Button
+                        variant="destructive"
+                        onClick={async () => {
+                          try {
+                            await deleteCommittee(committee.id);
+                            setCommittees((prev) =>
+                              prev.filter((c) => c.id !== committee.id),
+                            );
+                          } catch (error) {
+                            console.error("Failed to delete committee:", error);
+                            alert("Failed to delete committee.");
+                          }
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+
+                {expanded === committee.id && (
+                  <tr className="border-t bg-muted/20">
+                    <td className="p-3" colSpan={5}>
+                      <CommitteeDetail
+                        committee={committee}
+                        senators={senators}
+                        onUpdate={updateLocal}
+                      />
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   );
@@ -110,18 +176,22 @@ function CommitteeForm({
   onCreate,
 }: {
   senators: Senator[];
-  onCreate: (data: any) => Promise<void>;
+  onCreate: (data: CreateCommittee) => Promise<void>;
 }) {
-  const [form, setForm] = useState({
-    name: "",
-    description: "",
-    chair_senator_id: "",
-    chair_name: "",
-    chair_email: "",
-    is_active: true,
-  });
+  const [form, setForm] = useState<CommitteeFormState>(emptyCommitteeForm());
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  function handleChairChange(id: string) {
+  function handleChairChange(id: string): void {
+    if (!id) {
+      setForm((prev) => ({
+        ...prev,
+        chair_senator_id: "",
+        chair_name: "",
+        chair_email: "",
+      }));
+      return;
+    }
+
     const senator = senators.find((s) => s.id === Number(id));
     if (!senator) return;
 
@@ -138,24 +208,28 @@ function CommitteeForm({
       <h2 className="font-semibold">Create Committee</h2>
 
       <input
+        className="border px-3 py-1"
         placeholder="Name"
         value={form.name}
-        onChange={(e) =>
-          setForm({ ...form, name: e.target.value })
-        }
+        onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+        disabled={isSubmitting}
       />
 
       <textarea
+        className="border px-3 py-1"
         placeholder="Description"
         value={form.description}
         onChange={(e) =>
-          setForm({ ...form, description: e.target.value })
+          setForm((prev) => ({ ...prev, description: e.target.value }))
         }
+        disabled={isSubmitting}
       />
 
       <select
+        className="border px-3 py-1"
         value={form.chair_senator_id}
         onChange={(e) => handleChairChange(e.target.value)}
+        disabled={isSubmitting}
       >
         <option value="">Select Chair</option>
         {senators.map((s) => (
@@ -165,36 +239,39 @@ function CommitteeForm({
         ))}
       </select>
 
-      <input value={form.chair_name} disabled />
-      <input value={form.chair_email} disabled />
+      <input className="border px-3 py-1" value={form.chair_name} disabled />
+      <input className="border px-3 py-1" value={form.chair_email} disabled />
 
       <label className="flex items-center gap-2">
         <input
           type="checkbox"
           checked={form.is_active}
           onChange={(e) =>
-            setForm({ ...form, is_active: e.target.checked })
+            setForm((prev) => ({ ...prev, is_active: e.target.checked }))
           }
+          disabled={isSubmitting}
         />
         Active
       </label>
 
-      <button
+      <Button
         className="border px-3 py-1"
+        disabled={isSubmitting}
         onClick={async () => {
-          const res = await onCreate(form);
-          setForm({
-            name: "",
-            description: "",
-            chair_senator_id: "",
-            chair_name: "",
-            chair_email: "",
-            is_active: true,
-          });
+          setIsSubmitting(true);
+          try {
+            await onCreate(toCommitteePayload(form));
+            setForm(emptyCommitteeForm());
+          } catch (error) {
+            console.error("Failed to create committee:", error);
+            alert("Failed to create committee.");
+          } finally {
+            setIsSubmitting(false);
+          }
         }}
       >
-        Create
-      </button>
+        {isSubmitting ? "Creating..." : "Create"}
+      </Button>
     </div>
   );
 }
@@ -206,50 +283,174 @@ function CommitteeDetail({
 }: {
   committee: Committee;
   senators: Senator[];
-  onUpdate: (c: Committee) => void;
+  onUpdate: (committee: Committee) => void;
 }) {
   const [senatorId, setSenatorId] = useState("");
   const [role, setRole] = useState("");
+  const [isSavingCommittee, setIsSavingCommittee] = useState(false);
+  const [editForm, setEditForm] = useState<CommitteeFormState>({
+    name: committee.name,
+    description: committee.description,
+    chair_senator_id: "",
+    chair_name: committee.chair_name,
+    chair_email: committee.chair_email,
+    is_active: committee.is_active,
+  });
 
-  const existingIds = new Set(committee.members.map((m) => m.id));
+  useEffect(() => {
+    const inferredChair = senators.find(
+      (senator) => senator.email === committee.chair_email,
+    );
 
+    setEditForm({
+      name: committee.name,
+      description: committee.description,
+      chair_senator_id: inferredChair ? String(inferredChair.id) : "",
+      chair_name: committee.chair_name,
+      chair_email: committee.chair_email,
+      is_active: committee.is_active,
+    });
+  }, [committee, senators]);
+
+  const existingIds = new Set(committee.members.map((member) => member.id));
   const availableSenators = senators.filter(
-    (s) => !existingIds.has(s.id),
+    (senator) => !existingIds.has(senator.id),
   );
 
-  function getRole(member: any) {
+  function getRole(member: Senator): string {
     const assignment = member.committees?.find(
-      (c: any) => c.committee_id === committee.id,
+      (item: CommitteeAssignment) => item.committee_id === committee.id,
     );
     return assignment?.role ?? "Member";
   }
 
+  function handleChairChange(id: string): void {
+    if (!id) {
+      setEditForm((prev) => ({
+        ...prev,
+        chair_senator_id: "",
+        chair_name: "",
+        chair_email: "",
+      }));
+      return;
+    }
+
+    const senator = senators.find((s) => s.id === Number(id));
+    if (!senator) return;
+
+    setEditForm((prev) => ({
+      ...prev,
+      chair_senator_id: id,
+      chair_name: `${senator.first_name} ${senator.last_name}`,
+      chair_email: senator.email,
+    }));
+  }
+
   return (
     <div className="border rounded p-4 space-y-4">
+      <h3 className="font-semibold">Committee Details</h3>
+
+      <div className="grid gap-2">
+        <input
+          className="border px-3 py-1"
+          placeholder="Name"
+          value={editForm.name}
+          onChange={(e) =>
+            setEditForm((prev) => ({ ...prev, name: e.target.value }))
+          }
+        />
+
+        <textarea
+          className="border px-3 py-1"
+          placeholder="Description"
+          value={editForm.description}
+          onChange={(e) =>
+            setEditForm((prev) => ({ ...prev, description: e.target.value }))
+          }
+        />
+
+        <select
+          className="border px-3 py-1"
+          value={editForm.chair_senator_id}
+          onChange={(e) => handleChairChange(e.target.value)}
+        >
+          <option value="">Select Chair</option>
+          {senators.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.first_name} {s.last_name}
+            </option>
+          ))}
+        </select>
+
+        <input
+          className="border px-3 py-1"
+          value={editForm.chair_name}
+          disabled
+        />
+        <input
+          className="border px-3 py-1"
+          value={editForm.chair_email}
+          disabled
+        />
+
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={editForm.is_active}
+            onChange={(e) =>
+              setEditForm((prev) => ({ ...prev, is_active: e.target.checked }))
+            }
+          />
+          Active
+        </label>
+
+        <Button
+          variant="outline"
+          disabled={isSavingCommittee}
+          onClick={async () => {
+            setIsSavingCommittee(true);
+            try {
+              const updated = await updateCommittee(
+                committee.id,
+                toCommitteePayload(editForm),
+              );
+              onUpdate(updated);
+            } catch (error) {
+              console.error("Failed to update committee:", error);
+              alert("Failed to update committee.");
+            } finally {
+              setIsSavingCommittee(false);
+            }
+          }}
+        >
+          {isSavingCommittee ? "Saving..." : "Save Committee"}
+        </Button>
+      </div>
+
       <h3 className="font-semibold">Members</h3>
 
-      {/* Member list */}
       <div className="space-y-2">
-        {committee.members.map((m) => (
-          <div key={m.id} className="flex justify-between">
+        {committee.members.map((member) => (
+          <div key={member.id} className="flex justify-between">
             <span>
-              {m.first_name} {m.last_name} — {getRole(m)}
+              {member.first_name} {member.last_name} - {getRole(member)}
             </span>
 
             <button
               className="text-red-500"
               onClick={async () => {
-                await removeCommitteeMember(
-                  committee.id,
-                  m.id,
-                );
-
-                const updated = {
-                  ...committee,
-                  members: committee.members.filter((x) => x.id !== m.id),
-                };
-
-                onUpdate(updated);
+                try {
+                  await removeCommitteeMember(committee.id, member.id);
+                  onUpdate({
+                    ...committee,
+                    members: committee.members.filter(
+                      (m) => m.id !== member.id,
+                    ),
+                  });
+                } catch (error) {
+                  console.error("Failed to remove committee member:", error);
+                  alert("Failed to remove committee member.");
+                }
               }}
             >
               Remove
@@ -258,9 +459,9 @@ function CommitteeDetail({
         ))}
       </div>
 
-      {/* Add member */}
       <div className="flex gap-2 pt-2 border-t">
         <select
+          className="border px-3 py-1"
           value={senatorId}
           onChange={(e) => setSenatorId(e.target.value)}
         >
@@ -273,35 +474,58 @@ function CommitteeDetail({
         </select>
 
         <input
+          className="border px-3 py-1"
           placeholder="Role"
           value={role}
           onChange={(e) => setRole(e.target.value)}
         />
 
-        <button
-          className="border px-3"
+        <Button
+          variant="outline"
           onClick={async () => {
-            await assignCommitteeMember(committee.id, {
-              senator_id: Number(senatorId),
-              role,
-            });
+            if (!senatorId) {
+              alert("Please select a senator to add.");
+              return;
+            }
 
-            const senator = senators.find((s) => s.id === Number(senatorId));
-            if (!senator) return;
+            const selectedRole = role.trim() || "Member";
 
-            const updated: Committee = {
-              ...committee,
-              members: [...committee.members, senator],
-            };
+            try {
+              await assignCommitteeMember(committee.id, {
+                senator_id: Number(senatorId),
+                role: selectedRole,
+              });
 
-            onUpdate(updated);
+              const senator = senators.find((s) => s.id === Number(senatorId));
+              if (!senator) return;
 
-            setSenatorId("");
-            setRole("");
+              const updatedMember: Senator = {
+                ...senator,
+                committees: [
+                  ...(senator.committees ?? []),
+                  {
+                    committee_id: committee.id,
+                    committee_name: committee.name,
+                    role: selectedRole,
+                  },
+                ],
+              };
+
+              onUpdate({
+                ...committee,
+                members: [...committee.members, updatedMember],
+              });
+
+              setSenatorId("");
+              setRole("");
+            } catch (error) {
+              console.error("Failed to add committee member:", error);
+              alert("Failed to add committee member.");
+            }
           }}
         >
           Add Member
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/app/admin/committees/page.tsx
+++ b/frontend/src/app/admin/committees/page.tsx
@@ -1,3 +1,308 @@
-export default function AdminCommitteesPage() {
-  return <h1 className="text-2xl font-bold">Committees</h1>;
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  createCommittee,
+  updateCommittee,
+  deleteCommittee,
+  assignCommitteeMember,
+  removeCommitteeMember,
+} from "@/lib/admin-api";
+import { getSenators } from "@/lib/api";
+import type { Committee, Senator } from "@/types";
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function CommitteesPage() {
+  const [committees, setCommittees] = useState<Committee[]>([]);
+  const [senators, setSenators] = useState<Senator[]>([]);
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const [c, s] = await Promise.all([
+        fetch("/api/admin/committees").then((r) => r.json()),
+        getSenators(),
+      ]);
+      setCommittees(c);
+      setSenators(s);
+    }
+    load();
+  }, []);
+
+  function updateLocal(updated: Committee) {
+    setCommittees((prev) =>
+      prev.map((c) => (c.id === updated.id ? updated : c)),
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-4xl font-bold">Admin Committees</h1>
+
+      <CommitteeForm
+        senators={senators}
+        onCreate={async (data) => {
+          const res = await createCommittee(data);
+          setCommittees((p) => [...p, res]);
+        }}
+      />
+
+      <div className="grid gap-4">
+        {committees.map((c) => (
+          <Card key={c.id}>
+            <CardHeader>
+              <CardTitle>{c.name}</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Chair: {c.chair_name} •{" "}
+                {c.is_active ? "Active" : "Inactive"} •{" "}
+                {c.members.length} members
+              </p>
+            </CardHeader>
+
+            <CardContent className="space-y-3">
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    setExpanded(expanded === c.id ? null : c.id)
+                  }
+                >
+                  {expanded === c.id ? "Hide" : "Manage"}
+                </Button>
+
+                <Button
+                  variant="destructive"
+                  onClick={async () => {
+                    await deleteCommittee(c.id);
+                    setCommittees((p) =>
+                      p.filter((x) => x.id !== c.id),
+                    );
+                  }}
+                >
+                  Delete
+                </Button>
+              </div>
+
+              {expanded === c.id && (
+                <CommitteeDetail
+                  committee={c}
+                  senators={senators}
+                  onUpdate={updateLocal}
+                />
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CommitteeForm({
+  senators,
+  onCreate,
+}: {
+  senators: Senator[];
+  onCreate: (data: any) => Promise<void>;
+}) {
+  const [form, setForm] = useState({
+    name: "",
+    description: "",
+    chair_senator_id: "",
+    chair_name: "",
+    chair_email: "",
+    is_active: true,
+  });
+
+  function handleChairChange(id: string) {
+    const senator = senators.find((s) => s.id === Number(id));
+    if (!senator) return;
+
+    setForm((prev) => ({
+      ...prev,
+      chair_senator_id: id,
+      chair_name: `${senator.first_name} ${senator.last_name}`,
+      chair_email: senator.email,
+    }));
+  }
+
+  return (
+    <div className="border rounded p-4 space-y-3">
+      <h2 className="font-semibold">Create Committee</h2>
+
+      <input
+        placeholder="Name"
+        value={form.name}
+        onChange={(e) =>
+          setForm({ ...form, name: e.target.value })
+        }
+      />
+
+      <textarea
+        placeholder="Description"
+        value={form.description}
+        onChange={(e) =>
+          setForm({ ...form, description: e.target.value })
+        }
+      />
+
+      <select
+        value={form.chair_senator_id}
+        onChange={(e) => handleChairChange(e.target.value)}
+      >
+        <option value="">Select Chair</option>
+        {senators.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.first_name} {s.last_name}
+          </option>
+        ))}
+      </select>
+
+      <input value={form.chair_name} disabled />
+      <input value={form.chair_email} disabled />
+
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={form.is_active}
+          onChange={(e) =>
+            setForm({ ...form, is_active: e.target.checked })
+          }
+        />
+        Active
+      </label>
+
+      <button
+        className="border px-3 py-1"
+        onClick={async () => {
+          const res = await onCreate(form);
+          setForm({
+            name: "",
+            description: "",
+            chair_senator_id: "",
+            chair_name: "",
+            chair_email: "",
+            is_active: true,
+          });
+        }}
+      >
+        Create
+      </button>
+    </div>
+  );
+}
+
+function CommitteeDetail({
+  committee,
+  senators,
+  onUpdate,
+}: {
+  committee: Committee;
+  senators: Senator[];
+  onUpdate: (c: Committee) => void;
+}) {
+  const [senatorId, setSenatorId] = useState("");
+  const [role, setRole] = useState("");
+
+  const existingIds = new Set(committee.members.map((m) => m.id));
+
+  const availableSenators = senators.filter(
+    (s) => !existingIds.has(s.id),
+  );
+
+  function getRole(member: any) {
+    const assignment = member.committees?.find(
+      (c: any) => c.committee_id === committee.id,
+    );
+    return assignment?.role ?? "Member";
+  }
+
+  return (
+    <div className="border rounded p-4 space-y-4">
+      <h3 className="font-semibold">Members</h3>
+
+      {/* Member list */}
+      <div className="space-y-2">
+        {committee.members.map((m) => (
+          <div key={m.id} className="flex justify-between">
+            <span>
+              {m.first_name} {m.last_name} — {getRole(m)}
+            </span>
+
+            <button
+              className="text-red-500"
+              onClick={async () => {
+                await removeCommitteeMember(
+                  committee.id,
+                  m.id,
+                );
+
+                const updated = {
+                  ...committee,
+                  members: committee.members.filter((x) => x.id !== m.id),
+                };
+
+                onUpdate(updated);
+              }}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* Add member */}
+      <div className="flex gap-2 pt-2 border-t">
+        <select
+          value={senatorId}
+          onChange={(e) => setSenatorId(e.target.value)}
+        >
+          <option value="">Select senator</option>
+          {availableSenators.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.first_name} {s.last_name}
+            </option>
+          ))}
+        </select>
+
+        <input
+          placeholder="Role"
+          value={role}
+          onChange={(e) => setRole(e.target.value)}
+        />
+
+        <button
+          className="border px-3"
+          onClick={async () => {
+            await assignCommitteeMember(committee.id, {
+              senator_id: Number(senatorId),
+              role,
+            });
+
+            const senator = senators.find((s) => s.id === Number(senatorId));
+            if (!senator) return;
+
+            const updated: Committee = {
+              ...committee,
+              members: [...committee.members, senator],
+            };
+
+            onUpdate(updated);
+
+            setSenatorId("");
+            setRole("");
+          }}
+        >
+          Add Member
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -286,6 +286,12 @@ export async function deleteFinanceHearingDate(id: number): Promise<void> {
 }
 
 // Committees
+export async function getAdminCommittees(): Promise<Committee[]> {
+  return request("/admin/committees", {
+    method: "GET",
+  });
+}
+
 export async function createCommittee(
   data: CreateCommittee,
 ): Promise<Committee> {

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -124,6 +124,7 @@ export interface CreateCommittee {
   chair_senator_id: number | null;
   chair_name: string;
   chair_email: string;
+  is_active: boolean;
 }
 
 export interface AssignCommitteeMember {


### PR DESCRIPTION
Motivation: 
Admins manage committees and their membership rosters. This page needs both committee-level CRUD and a member assignment sub-interface.

Changes: 
 - Built /admin/committees/page.tsx 
 - Implemented a committee detail sub-view (expandable row or separate modal): shows current members with roles and a "Remove" button per member
 - With "Add Member" button in detail view: senator dropdown + role input
 - Wired to admin committee and membership API functions

Closes #95 

Author Note : Am still working on.