### PR TITLE
Admin API Routes — Events, Carousel, Staff, Finance, Budget, Pages, Districts, Accounts (#71)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,11 +20,19 @@ from app.routers import (
     senators,
     staff,
 )
+from app.routers.admin import accounts as admin_accounts
+from app.routers.admin import budget as admin_budget
+from app.routers.admin import carousel as admin_carousel
 from app.routers.admin import committees as admin_committees
+from app.routers.admin import districts as admin_districts
+from app.routers.admin import events as admin_events
+from app.routers.admin import finance as admin_finance
 from app.routers.admin import leadership as admin_leadership
 from app.routers.admin import legislation as admin_legislation
 from app.routers.admin import news as admin_news
+from app.routers.admin import pages as admin_pages
 from app.routers.admin import senators as admin_senators
+from app.routers.admin import staff as admin_staff
 
 load_dotenv()
 
@@ -65,6 +73,14 @@ app.include_router(admin_committees.router)
 app.include_router(admin_legislation.router)
 app.include_router(admin_senators.router)
 app.include_router(admin_leadership.router)
+app.include_router(admin_events.router)
+app.include_router(admin_carousel.router)
+app.include_router(admin_staff.router)
+app.include_router(admin_finance.router)
+app.include_router(admin_budget.router)
+app.include_router(admin_pages.router)
+app.include_router(admin_districts.router)
+app.include_router(admin_accounts.router)
 
 
 @app.get("/")

--- a/backend/app/routers/admin/accounts.py
+++ b/backend/app/routers/admin/accounts.py
@@ -1,0 +1,116 @@
+"""Admin account management routes (admin role required for all).
+
+GET    /api/admin/accounts       — paginated list of admin/staff accounts
+POST   /api/admin/accounts       — create account
+PUT    /api/admin/accounts/{id}  — update account fields
+DELETE /api/admin/accounts/{id}  — delete account
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import require_role
+from app.models.Admin import Admin
+from app.schemas.account import AccountDTO, CreateAccountDTO, UpdateAccountDTO
+from app.schemas.pagination import PaginatedResponse
+from app.utils.pagination import paginate
+
+router = APIRouter(
+    prefix="/api/admin/accounts",
+    tags=["admin", "accounts"],
+)
+
+
+@router.get("", response_model=PaginatedResponse[AccountDTO])
+def list_admin_accounts(
+    page: int = Query(default=1, ge=1, description="1-based page number"),
+    limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+    _current_user: Admin = Depends(require_role("admin")),
+    db: Session = Depends(get_db),
+):
+    """Return a paginated list of all accounts. Admin role required."""
+    query = db.query(Admin).order_by(Admin.last_name, Admin.first_name)
+    items, total = paginate(query, page=page, limit=limit)
+    return PaginatedResponse(
+        items=[AccountDTO.model_validate(a) for a in items],
+        total=total,
+        page=page,
+        limit=limit,
+    )
+
+
+@router.post("", response_model=AccountDTO, status_code=status.HTTP_201_CREATED)
+def create_admin_account(
+    body: CreateAccountDTO,
+    _current_user: Admin = Depends(require_role("admin")),
+    db: Session = Depends(get_db),
+):
+    """Create an admin or staff account. Admin role required."""
+    account = Admin(**body.model_dump())
+    db.add(account)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail="Account with that email or PID already exists",
+        )
+    db.refresh(account)
+    return AccountDTO.model_validate(account)
+
+
+@router.put(
+    "/{account_id}",
+    response_model=AccountDTO,
+    responses={404: {"description": "Account not found"}},
+)
+def update_admin_account(
+    account_id: int,
+    body: UpdateAccountDTO,
+    _current_user: Admin = Depends(require_role("admin")),
+    db: Session = Depends(get_db),
+):
+    """Update account fields. Unset fields remain unchanged. Admin role required."""
+    account = db.query(Admin).filter(Admin.id == account_id).first()
+    if account is None:
+        raise HTTPException(status_code=404, detail="Account not found")
+
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(account, field, value)
+
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail="Update would conflict with an existing account (duplicate email or PID)",
+        )
+    db.refresh(account)
+    return AccountDTO.model_validate(account)
+
+
+@router.delete(
+    "/{account_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={404: {"description": "Account not found"}},
+)
+def delete_admin_account(
+    account_id: int,
+    current_user: Admin = Depends(require_role("admin")),
+    db: Session = Depends(get_db),
+):
+    """Delete an account. Admin role required. Cannot delete your own account."""
+    if account_id == current_user.id:
+        raise HTTPException(status_code=400, detail="Cannot delete your own account")
+
+    account = db.query(Admin).filter(Admin.id == account_id).first()
+    if account is None:
+        raise HTTPException(status_code=404, detail="Account not found")
+
+    db.delete(account)
+    db.commit()
+    return None

--- a/backend/app/routers/admin/budget.py
+++ b/backend/app/routers/admin/budget.py
@@ -1,0 +1,121 @@
+"""Admin budget CRUD routes.
+
+GET    /api/admin/budget       — flat list; optional fiscal_year filter
+POST   /api/admin/budget       — create budget entry; updated_by set from JWT
+PUT    /api/admin/budget/{id}  — update budget entry fields
+DELETE /api/admin/budget/{id}  — delete budget entry
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.Admin import Admin
+from app.models.BudgetData import BudgetData
+from app.schemas.budget import AdminBudgetDataDTO, CreateBudgetDataDTO, UpdateBudgetDataDTO
+
+router = APIRouter(
+    prefix="/api/admin/budget",
+    tags=["admin", "budget"],
+)
+
+
+@router.get("", response_model=list[AdminBudgetDataDTO])
+def list_admin_budget(
+    fiscal_year: Optional[str] = Query(default=None, description="Filter by fiscal year"),
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return a flat list of all budget entries, optionally filtered by fiscal year."""
+    query = db.query(BudgetData).order_by(BudgetData.display_order)
+    if fiscal_year is not None:
+        query = query.filter(BudgetData.fiscal_year == fiscal_year)
+    return [AdminBudgetDataDTO.model_validate(row) for row in query.all()]
+
+
+@router.post("", response_model=AdminBudgetDataDTO, status_code=status.HTTP_201_CREATED)
+def create_admin_budget(
+    body: CreateBudgetDataDTO,
+    current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a budget entry. updated_by is set from the authenticated user."""
+    if body.parent_category_id is not None:
+        parent = db.query(BudgetData).filter(BudgetData.id == body.parent_category_id).first()
+        if parent is None:
+            raise HTTPException(status_code=404, detail="Parent category not found")
+
+    entry = BudgetData(**body.model_dump(), updated_by=current_user.id)
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return AdminBudgetDataDTO.model_validate(entry)
+
+
+@router.put(
+    "/{budget_id}",
+    response_model=AdminBudgetDataDTO,
+    responses={404: {"description": "Budget entry not found"}},
+)
+def update_admin_budget(
+    budget_id: int,
+    body: UpdateBudgetDataDTO,
+    current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update budget entry fields. Unset fields remain unchanged."""
+    entry = db.query(BudgetData).filter(BudgetData.id == budget_id).first()
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Budget entry not found")
+
+    update_data = body.model_dump(exclude_unset=True)
+
+    if "parent_category_id" in update_data and update_data["parent_category_id"] is not None:
+        if update_data["parent_category_id"] == budget_id:
+            raise HTTPException(status_code=400, detail="Budget entry cannot be its own parent")
+        parent = db.query(BudgetData).filter(
+            BudgetData.id == update_data["parent_category_id"]
+        ).first()
+        if parent is None:
+            raise HTTPException(status_code=404, detail="Parent category not found")
+
+    for field, value in update_data.items():
+        setattr(entry, field, value)
+    entry.updated_by = current_user.id
+
+    db.commit()
+    db.refresh(entry)
+    return AdminBudgetDataDTO.model_validate(entry)
+
+
+@router.delete(
+    "/{budget_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        404: {"description": "Budget entry not found"},
+        409: {"description": "Budget entry has child entries"},
+    },
+)
+def delete_admin_budget(
+    budget_id: int,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Delete a budget entry. Blocked if it has child entries."""
+    entry = db.query(BudgetData).filter(BudgetData.id == budget_id).first()
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Budget entry not found")
+
+    child = db.query(BudgetData).filter(BudgetData.parent_category_id == budget_id).first()
+    if child is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Budget entry has child entries; delete or reparent them first",
+        )
+
+    db.delete(entry)
+    db.commit()
+    return None

--- a/backend/app/routers/admin/carousel.py
+++ b/backend/app/routers/admin/carousel.py
@@ -1,0 +1,113 @@
+"""Admin carousel slide CRUD routes.
+
+POST /api/admin/carousel          — create slide
+PUT  /api/admin/carousel/reorder  — batch reorder slides by ordered slide_ids list
+PUT  /api/admin/carousel/{id}     — update slide fields
+DELETE /api/admin/carousel/{id}   — delete slide
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.Admin import Admin
+from app.models.CarouselSlide import CarouselSlide
+from app.schemas.carousel import (
+    CarouselSlideDTO,
+    CreateCarouselSlideDTO,
+    ReorderCarouselDTO,
+    UpdateCarouselSlideDTO,
+)
+
+router = APIRouter(
+    prefix="/api/admin/carousel",
+    tags=["admin", "carousel"],
+)
+
+
+@router.post("", response_model=CarouselSlideDTO, status_code=status.HTTP_201_CREATED)
+def create_admin_slide(
+    body: CreateCarouselSlideDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a carousel slide."""
+    slide = CarouselSlide(**body.model_dump())
+    db.add(slide)
+    db.commit()
+    db.refresh(slide)
+    return CarouselSlideDTO.model_validate(slide)
+
+
+@router.put(
+    "/reorder",
+    response_model=list[CarouselSlideDTO],
+    responses={400: {"description": "slide_ids do not match existing slides"}},
+)
+def reorder_admin_slides(
+    body: ReorderCarouselDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Batch-reorder carousel slides. Accepts an ordered list of slide IDs and
+    updates display_order to match the given ordering (1-based)."""
+    slides = {s.id: s for s in db.query(CarouselSlide).all()}
+
+    if set(body.slide_ids) != set(slides.keys()):
+        raise HTTPException(
+            status_code=400,
+            detail="slide_ids must contain exactly the IDs of all existing slides",
+        )
+
+    for order, slide_id in enumerate(body.slide_ids, start=1):
+        slides[slide_id].display_order = order
+
+    db.commit()
+
+    ordered = sorted(slides.values(), key=lambda s: s.display_order)
+    return [CarouselSlideDTO.model_validate(s) for s in ordered]
+
+
+@router.put(
+    "/{slide_id}",
+    response_model=CarouselSlideDTO,
+    responses={404: {"description": "Slide not found"}},
+)
+def update_admin_slide(
+    slide_id: int,
+    body: UpdateCarouselSlideDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update carousel slide fields. Unset fields remain unchanged."""
+    slide = db.query(CarouselSlide).filter(CarouselSlide.id == slide_id).first()
+    if slide is None:
+        raise HTTPException(status_code=404, detail="Slide not found")
+
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(slide, field, value)
+
+    db.commit()
+    db.refresh(slide)
+    return CarouselSlideDTO.model_validate(slide)
+
+
+@router.delete(
+    "/{slide_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={404: {"description": "Slide not found"}},
+)
+def delete_admin_slide(
+    slide_id: int,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Delete a carousel slide."""
+    slide = db.query(CarouselSlide).filter(CarouselSlide.id == slide_id).first()
+    if slide is None:
+        raise HTTPException(status_code=404, detail="Slide not found")
+
+    db.delete(slide)
+    db.commit()
+    return None

--- a/backend/app/routers/admin/districts.py
+++ b/backend/app/routers/admin/districts.py
@@ -1,0 +1,104 @@
+"""Admin district CRUD routes.
+
+GET    /api/admin/districts       — list all districts
+POST   /api/admin/districts       — create district
+PUT    /api/admin/districts/{id}  — update district fields
+DELETE /api/admin/districts/{id}  — delete district
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.Admin import Admin
+from app.models.District import District
+from app.schemas.district import AdminDistrictDTO, CreateDistrictDTO, UpdateDistrictDTO
+
+router = APIRouter(
+    prefix="/api/admin/districts",
+    tags=["admin", "districts"],
+)
+
+
+@router.get("", response_model=list[AdminDistrictDTO])
+def list_admin_districts(
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return all districts."""
+    districts = db.query(District).order_by(District.district_name).all()
+    return [AdminDistrictDTO.model_validate(d) for d in districts]
+
+
+@router.post("", response_model=AdminDistrictDTO, status_code=status.HTTP_201_CREATED)
+def create_admin_district(
+    body: CreateDistrictDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a district."""
+    district = District(**body.model_dump())
+    db.add(district)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Unable to create district due to invalid data")
+    db.refresh(district)
+    return AdminDistrictDTO.model_validate(district)
+
+
+@router.put(
+    "/{district_id}",
+    response_model=AdminDistrictDTO,
+    responses={404: {"description": "District not found"}},
+)
+def update_admin_district(
+    district_id: int,
+    body: UpdateDistrictDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update district fields. Unset fields remain unchanged."""
+    district = db.query(District).filter(District.id == district_id).first()
+    if district is None:
+        raise HTTPException(status_code=404, detail="District not found")
+
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(district, field, value)
+
+    db.commit()
+    db.refresh(district)
+    return AdminDistrictDTO.model_validate(district)
+
+
+@router.delete(
+    "/{district_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        404: {"description": "District not found"},
+        409: {"description": "District has linked senators"},
+    },
+)
+def delete_admin_district(
+    district_id: int,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Delete a district. Blocked if senators are still assigned to it."""
+    district = db.query(District).filter(District.id == district_id).first()
+    if district is None:
+        raise HTTPException(status_code=404, detail="District not found")
+
+    try:
+        db.delete(district)
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="District has linked senators; reassign or delete them first",
+        )
+    return None

--- a/backend/app/routers/admin/events.py
+++ b/backend/app/routers/admin/events.py
@@ -1,0 +1,83 @@
+"""Admin calendar event CRUD routes.
+
+POST   /api/admin/events       — create event; created_by set from JWT
+PUT    /api/admin/events/{id}  — update event fields
+DELETE /api/admin/events/{id}  — delete event (admin role required)
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user, require_role
+from app.models.Admin import Admin
+from app.models.CalendarEvent import CalendarEvent
+from app.schemas.calendar_event import (
+    AdminCalendarEventDTO,
+    CreateAdminCalendarEventDTO,
+    UpdateCalendarEventDTO,
+)
+
+router = APIRouter(
+    prefix="/api/admin/events",
+    tags=["admin", "events"],
+)
+
+
+@router.post("", response_model=AdminCalendarEventDTO, status_code=status.HTTP_201_CREATED)
+def create_admin_event(
+    body: CreateAdminCalendarEventDTO,
+    current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a calendar event. created_by is set from the authenticated user."""
+    event = CalendarEvent(**body.model_dump(), created_by=current_user.id)
+    db.add(event)
+    db.commit()
+    db.refresh(event)
+    return AdminCalendarEventDTO.model_validate(event)
+
+
+@router.put(
+    "/{event_id}",
+    response_model=AdminCalendarEventDTO,
+    responses={404: {"description": "Event not found"}},
+)
+def update_admin_event(
+    event_id: int,
+    body: UpdateCalendarEventDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update event fields. Unset fields remain unchanged."""
+    event = db.query(CalendarEvent).filter(CalendarEvent.id == event_id).first()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    update_data = body.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(event, field, value)
+
+    db.commit()
+    db.refresh(event)
+    return AdminCalendarEventDTO.model_validate(event)
+
+
+@router.delete(
+    "/{event_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={404: {"description": "Event not found"}},
+)
+def delete_admin_event(
+    event_id: int,
+    _current_user: Admin = Depends(require_role("admin")),
+    db: Session = Depends(get_db),
+):
+    """Delete a calendar event. Requires admin role."""
+    event = db.query(CalendarEvent).filter(CalendarEvent.id == event_id).first()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    db.delete(event)
+    db.commit()
+    return None

--- a/backend/app/routers/admin/finance.py
+++ b/backend/app/routers/admin/finance.py
@@ -1,0 +1,127 @@
+"""Admin finance hearing CRUD routes.
+
+PUT    /api/admin/finance-hearings/config       — update singleton config; updated_by from JWT
+POST   /api/admin/finance-hearings/dates        — create hearing date
+PUT    /api/admin/finance-hearings/dates/{id}   — update hearing date fields
+DELETE /api/admin/finance-hearings/dates/{id}   — delete hearing date
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.Admin import Admin
+from app.models.FinanceHearingConfig import FinanceHearingConfig
+from app.models.FinanceHearingDate import FinanceHearingDate
+from app.schemas.finance import (
+    CreateFinanceHearingDateDTO,
+    FinanceHearingConfigDTO,
+    FinanceHearingDateDTO,
+    UpdateFinanceHearingConfigDTO,
+    UpdateFinanceHearingDateDTO,
+)
+
+router = APIRouter(
+    prefix="/api/admin/finance-hearings",
+    tags=["admin", "finance"],
+)
+
+
+@router.put("/config", response_model=FinanceHearingConfigDTO)
+def update_finance_config(
+    body: UpdateFinanceHearingConfigDTO,
+    current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update (or create) the singleton finance hearing configuration."""
+    config = db.query(FinanceHearingConfig).first()
+    if config is None:
+        config = FinanceHearingConfig(
+            is_active=body.is_active,
+            season_start=body.season_start,
+            season_end=body.season_end,
+            updated_by=current_user.id,
+        )
+        db.add(config)
+    else:
+        config.is_active = body.is_active
+        config.season_start = body.season_start
+        config.season_end = body.season_end
+        config.updated_by = current_user.id
+
+    db.commit()
+    db.refresh(config)
+
+    dates = [
+        FinanceHearingDateDTO.model_validate(d) for d in db.query(FinanceHearingDate).all()
+    ] if config.is_active else []
+
+    return FinanceHearingConfigDTO(
+        is_active=config.is_active,
+        season_start=config.season_start,
+        season_end=config.season_end,
+        dates=dates,
+    )
+
+
+@router.post(
+    "/dates",
+    response_model=FinanceHearingDateDTO,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_finance_date(
+    body: CreateFinanceHearingDateDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a finance hearing date slot."""
+    date_entry = FinanceHearingDate(**body.model_dump())
+    db.add(date_entry)
+    db.commit()
+    db.refresh(date_entry)
+    return FinanceHearingDateDTO.model_validate(date_entry)
+
+
+@router.put(
+    "/dates/{date_id}",
+    response_model=FinanceHearingDateDTO,
+    responses={404: {"description": "Hearing date not found"}},
+)
+def update_finance_date(
+    date_id: int,
+    body: UpdateFinanceHearingDateDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update finance hearing date fields. Unset fields remain unchanged."""
+    date_entry = db.query(FinanceHearingDate).filter(FinanceHearingDate.id == date_id).first()
+    if date_entry is None:
+        raise HTTPException(status_code=404, detail="Hearing date not found")
+
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(date_entry, field, value)
+
+    db.commit()
+    db.refresh(date_entry)
+    return FinanceHearingDateDTO.model_validate(date_entry)
+
+
+@router.delete(
+    "/dates/{date_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={404: {"description": "Hearing date not found"}},
+)
+def delete_finance_date(
+    date_id: int,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Delete a finance hearing date slot."""
+    date_entry = db.query(FinanceHearingDate).filter(FinanceHearingDate.id == date_id).first()
+    if date_entry is None:
+        raise HTTPException(status_code=404, detail="Hearing date not found")
+
+    db.delete(date_entry)
+    db.commit()
+    return None

--- a/backend/app/routers/admin/pages.py
+++ b/backend/app/routers/admin/pages.py
@@ -1,0 +1,54 @@
+"""Admin static pages routes.
+
+GET /api/admin/pages        — list all static pages
+PUT /api/admin/pages/{slug} — update page content; last_edited_by set from JWT
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.Admin import Admin
+from app.models.cms import StaticPageContent
+from app.schemas.static_page import StaticPageDTO, UpdateStaticPageDTO
+
+router = APIRouter(
+    prefix="/api/admin/pages",
+    tags=["admin", "pages"],
+)
+
+
+@router.get("", response_model=list[StaticPageDTO])
+def list_admin_pages(
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return all static pages."""
+    pages = db.query(StaticPageContent).order_by(StaticPageContent.page_slug).all()
+    return [StaticPageDTO.model_validate(p) for p in pages]
+
+
+@router.put(
+    "/{slug}",
+    response_model=StaticPageDTO,
+    responses={404: {"description": "Page not found"}},
+)
+def update_admin_page(
+    slug: str,
+    body: UpdateStaticPageDTO,
+    current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update static page content. Pages are pre-seeded; only editing is allowed."""
+    page = db.query(StaticPageContent).filter(StaticPageContent.page_slug == slug).first()
+    if page is None:
+        raise HTTPException(status_code=404, detail="Page not found")
+
+    page.title = body.title
+    page.body = body.body
+    page.last_edited_by = current_user.id
+
+    db.commit()
+    db.refresh(page)
+    return StaticPageDTO.model_validate(page)

--- a/backend/app/routers/admin/staff.py
+++ b/backend/app/routers/admin/staff.py
@@ -1,0 +1,78 @@
+"""Admin staff CRUD routes.
+
+POST   /api/admin/staff       — create staff member
+PUT    /api/admin/staff/{id}  — update staff fields
+DELETE /api/admin/staff/{id}  — delete staff member
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.Admin import Admin
+from app.models.cms import Staff
+from app.schemas.staff import CreateStaffDTO, StaffDTO, UpdateStaffDTO
+
+router = APIRouter(
+    prefix="/api/admin/staff",
+    tags=["admin", "staff"],
+)
+
+
+@router.post("", response_model=StaffDTO, status_code=status.HTTP_201_CREATED)
+def create_admin_staff(
+    body: CreateStaffDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a staff member."""
+    staff = Staff(**body.model_dump())
+    db.add(staff)
+    db.commit()
+    db.refresh(staff)
+    return StaffDTO.model_validate(staff)
+
+
+@router.put(
+    "/{staff_id}",
+    response_model=StaffDTO,
+    responses={404: {"description": "Staff member not found"}},
+)
+def update_admin_staff(
+    staff_id: int,
+    body: UpdateStaffDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update staff fields. Unset fields remain unchanged."""
+    staff = db.query(Staff).filter(Staff.id == staff_id).first()
+    if staff is None:
+        raise HTTPException(status_code=404, detail="Staff member not found")
+
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(staff, field, value)
+
+    db.commit()
+    db.refresh(staff)
+    return StaffDTO.model_validate(staff)
+
+
+@router.delete(
+    "/{staff_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={404: {"description": "Staff member not found"}},
+)
+def delete_admin_staff(
+    staff_id: int,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Delete a staff member."""
+    staff = db.query(Staff).filter(Staff.id == staff_id).first()
+    if staff is None:
+        raise HTTPException(status_code=404, detail="Staff member not found")
+
+    db.delete(staff)
+    db.commit()
+    return None

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -30,3 +30,18 @@ class CreateAccountDTO(BaseModel):
         if not re.fullmatch(r"\d{9}", v):
             raise ValueError("PID must be exactly 9 digits")
         return v
+
+
+class UpdateAccountDTO(BaseModel):
+    email: EmailStr | None = None
+    pid: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+    role: Literal["admin", "staff"] | None = None
+
+    @field_validator("pid")
+    @classmethod
+    def pid_must_be_nine_digits(cls, v: str | None) -> str | None:
+        if v is not None and not re.fullmatch(r"\d{9}", v):
+            raise ValueError("PID must be exactly 9 digits")
+        return v

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -31,3 +31,24 @@ class CreateBudgetDataDTO(BaseModel):
         if v <= 0:
             raise ValueError("Amount must be positive")
         return v
+
+
+class AdminBudgetDataDTO(BaseModel):
+    id: int
+    fiscal_year: str
+    category: str
+    amount: float
+    description: str | None
+    parent_category_id: int | None
+    display_order: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UpdateBudgetDataDTO(BaseModel):
+    fiscal_year: str | None = None
+    category: str | None = None
+    amount: float | None = None
+    description: str | None = None
+    parent_category_id: int | None = None
+    display_order: int | None = None

--- a/backend/app/schemas/calendar_event.py
+++ b/backend/app/schemas/calendar_event.py
@@ -17,6 +17,19 @@ class CalendarEventDTO(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class AdminCalendarEventDTO(BaseModel):
+    id: int
+    title: str
+    description: str | None
+    start_datetime: datetime
+    end_datetime: datetime
+    location: str | None
+    event_type: str
+    is_published: bool
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class CreateCalendarEventDTO(BaseModel):
     title: str
     description: str | None
@@ -30,3 +43,29 @@ class CreateCalendarEventDTO(BaseModel):
         if self.end_datetime <= self.start_datetime:
             raise ValueError("end_datetime must be after start_datetime")
         return self
+
+
+class CreateAdminCalendarEventDTO(BaseModel):
+    title: str
+    description: str | None = None
+    start_datetime: datetime
+    end_datetime: datetime
+    location: str | None = None
+    event_type: str
+    is_published: bool = False
+
+    @model_validator(mode="after")
+    def end_must_be_after_start(self) -> "CreateAdminCalendarEventDTO":
+        if self.end_datetime <= self.start_datetime:
+            raise ValueError("end_datetime must be after start_datetime")
+        return self
+
+
+class UpdateCalendarEventDTO(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    start_datetime: datetime | None = None
+    end_datetime: datetime | None = None
+    location: str | None = None
+    event_type: str | None = None
+    is_published: bool | None = None

--- a/backend/app/schemas/carousel.py
+++ b/backend/app/schemas/carousel.py
@@ -20,3 +20,15 @@ class CreateCarouselSlideDTO(BaseModel):
     link_url: str
     display_order: int
     is_active: bool
+
+
+class UpdateCarouselSlideDTO(BaseModel):
+    image_url: str | None = None
+    overlay_text: str | None = None
+    link_url: str | None = None
+    display_order: int | None = None
+    is_active: bool | None = None
+
+
+class ReorderCarouselDTO(BaseModel):
+    slide_ids: list[int]

--- a/backend/app/schemas/district.py
+++ b/backend/app/schemas/district.py
@@ -14,5 +14,23 @@ class DistrictDTO(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class AdminDistrictDTO(BaseModel):
+    id: int
+    district_name: str
+    description: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class DistrictLookupDTO(BaseModel):
     query: str
+
+
+class CreateDistrictDTO(BaseModel):
+    district_name: str
+    description: str | None = None
+
+
+class UpdateDistrictDTO(BaseModel):
+    district_name: str | None = None
+    description: str | None = None

--- a/backend/app/schemas/finance.py
+++ b/backend/app/schemas/finance.py
@@ -36,3 +36,11 @@ class CreateFinanceHearingDateDTO(BaseModel):
     hearing_time: time
     location: str | None
     description: str | None
+
+
+class UpdateFinanceHearingDateDTO(BaseModel):
+    hearing_date: date | None = None
+    hearing_time: time | None = None
+    location: str | None = None
+    description: str | None = None
+    is_full: bool | None = None

--- a/backend/app/schemas/staff.py
+++ b/backend/app/schemas/staff.py
@@ -20,3 +20,13 @@ class CreateStaffDTO(BaseModel):
     title: str
     email: EmailStr
     display_order: int
+
+
+class UpdateStaffDTO(BaseModel):
+    first_name: str | None = None
+    last_name: str | None = None
+    title: str | None = None
+    email: EmailStr | None = None
+    photo_url: str | None = None
+    display_order: int | None = None
+    is_active: bool | None = None

--- a/backend/tests/routes/test_admin_accounts.py
+++ b/backend/tests/routes/test_admin_accounts.py
@@ -1,0 +1,300 @@
+"""Integration tests for admin account management routes (ticket #71).
+
+All routes are admin-role only — staff users should receive 403 on all endpoints.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin
+from app.models.base import Base
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+def _make_engine():
+    engine = create_engine(_SQLITE_URL, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    original = {t: set(t.constraints) for t in Base.metadata.tables.values()}
+    try:
+        for t in Base.metadata.tables.values():
+            t.constraints = {c for c in t.constraints if not isinstance(c, CheckConstraint)}
+        Base.metadata.create_all(bind=engine)
+    finally:
+        for t, constraints in original.items():
+            t.constraints = constraints
+    return engine
+
+
+def _seed(engine):
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    admin_user = Admin(email="admin@unc.edu", first_name="Admin", last_name="User", pid="100000001", role="admin")
+    staff_user = Admin(email="staff@unc.edu", first_name="Staff", last_name="User", pid="200000002", role="staff")
+    db.add_all([admin_user, staff_user])
+    db.commit()
+    db.close()
+
+
+def _clear():
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture(scope="module")
+def read_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def admin_read_client(read_engine):
+    TestSession = sessionmaker(bind=read_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+@pytest.fixture()
+def write_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_admin_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+@pytest.fixture()
+def write_staff_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "staff@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+_CREATE_PAYLOAD = {
+    "email": "newuser@unc.edu",
+    "pid": "300000003",
+    "first_name": "New",
+    "last_name": "User",
+    "role": "staff",
+}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/accounts
+# ---------------------------------------------------------------------------
+
+
+class TestListAdminAccounts:
+    def test_returns_200(self, admin_read_client):
+        assert admin_read_client.get("/api/admin/accounts").status_code == 200
+
+    def test_pagination_shape(self, admin_read_client):
+        data = admin_read_client.get("/api/admin/accounts").json()
+        for key in ("items", "total", "page", "limit"):
+            assert key in data
+
+    def test_returns_both_accounts(self, admin_read_client):
+        data = admin_read_client.get("/api/admin/accounts").json()
+        assert data["total"] == 2
+
+    def test_response_shape(self, admin_read_client):
+        item = admin_read_client.get("/api/admin/accounts").json()["items"][0]
+        for key in ("id", "email", "pid", "first_name", "last_name", "role"):
+            assert key in item
+
+    def test_staff_cannot_list(self, read_engine):
+        TestSession = sessionmaker(bind=read_engine)
+
+        def _override_get_db():
+            db = TestSession()
+            try:
+                yield db
+            finally:
+                db.close()
+
+        def _override_current_user():
+            db = TestSession()
+            user = db.query(Admin).filter(Admin.email == "staff@unc.edu").first()
+            db.close()
+            return user
+
+        app.dependency_overrides[get_db] = _override_get_db
+        app.dependency_overrides[get_current_user] = _override_current_user
+        try:
+            with TestClient(app) as c:
+                assert c.get("/api/admin/accounts").status_code == 403
+        finally:
+            _clear()
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.get("/api/admin/accounts").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/accounts
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAdminAccount:
+    def test_returns_201(self, write_admin_client):
+        assert write_admin_client.post("/api/admin/accounts", json=_CREATE_PAYLOAD).status_code == 201
+
+    def test_response_shape(self, write_admin_client):
+        resp = write_admin_client.post("/api/admin/accounts", json=_CREATE_PAYLOAD).json()
+        for key in ("id", "email", "pid", "role"):
+            assert key in resp
+
+    def test_duplicate_email_returns_400(self, write_admin_client):
+        bad = {**_CREATE_PAYLOAD, "pid": "400000004"}
+        write_admin_client.post("/api/admin/accounts", json=_CREATE_PAYLOAD)
+        assert write_admin_client.post("/api/admin/accounts", json=bad).status_code == 400
+
+    def test_invalid_pid_returns_422(self, write_admin_client):
+        bad = {**_CREATE_PAYLOAD, "pid": "123"}
+        assert write_admin_client.post("/api/admin/accounts", json=bad).status_code == 422
+
+    def test_invalid_role_returns_422(self, write_admin_client):
+        bad = {**_CREATE_PAYLOAD, "role": "superadmin"}
+        assert write_admin_client.post("/api/admin/accounts", json=bad).status_code == 422
+
+    def test_staff_cannot_create(self, write_staff_client):
+        assert write_staff_client.post("/api/admin/accounts", json=_CREATE_PAYLOAD).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/accounts/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAdminAccount:
+    def _create_account(self, client) -> int:
+        return client.post("/api/admin/accounts", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_200(self, write_admin_client):
+        account_id = self._create_account(write_admin_client)
+        assert write_admin_client.put(f"/api/admin/accounts/{account_id}", json={"first_name": "Updated"}).status_code == 200
+
+    def test_fields_updated(self, write_admin_client):
+        account_id = self._create_account(write_admin_client)
+        resp = write_admin_client.put(f"/api/admin/accounts/{account_id}", json={"first_name": "Changed", "role": "admin"})
+        assert resp.json()["first_name"] == "Changed"
+        assert resp.json()["role"] == "admin"
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/accounts/999999", json={"first_name": "X"}).status_code == 404
+
+    def test_staff_cannot_update(self, write_staff_client):
+        assert write_staff_client.put("/api/admin/accounts/1", json={"first_name": "X"}).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/accounts/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAdminAccount:
+    def _create_account(self, client) -> int:
+        return client.post("/api/admin/accounts", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_204(self, write_admin_client):
+        account_id = self._create_account(write_admin_client)
+        assert write_admin_client.delete(f"/api/admin/accounts/{account_id}").status_code == 204
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.delete("/api/admin/accounts/999999").status_code == 404
+
+    def test_staff_cannot_delete(self, write_staff_client):
+        assert write_staff_client.delete("/api/admin/accounts/1").status_code == 403
+
+    def test_cannot_delete_self(self, write_admin_client, write_engine):
+        db = sessionmaker(bind=write_engine)()
+        admin = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        assert write_admin_client.delete(f"/api/admin/accounts/{admin.id}").status_code == 400
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.delete("/api/admin/accounts/1").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved

--- a/backend/tests/routes/test_admin_budget.py
+++ b/backend/tests/routes/test_admin_budget.py
@@ -1,0 +1,259 @@
+"""Integration tests for admin budget CRUD routes (ticket #71)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin
+from app.models.base import Base
+from app.models.BudgetData import BudgetData
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+def _make_engine():
+    engine = create_engine(_SQLITE_URL, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    original = {t: set(t.constraints) for t in Base.metadata.tables.values()}
+    try:
+        for t in Base.metadata.tables.values():
+            t.constraints = {c for c in t.constraints if not isinstance(c, CheckConstraint)}
+        Base.metadata.create_all(bind=engine)
+    finally:
+        for t, constraints in original.items():
+            t.constraints = constraints
+    return engine
+
+
+def _seed(engine) -> tuple[int, int]:
+    """Returns (parent_id, child_id) of seeded budget rows."""
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    admin_user = Admin(email="admin@unc.edu", first_name="Admin", last_name="User", pid="100000001", role="admin")
+    db.add(admin_user)
+    db.flush()
+    parent = BudgetData(fiscal_year="FY2026", category="Operations", amount=100000.00, description=None, parent_category_id=None, display_order=1, updated_by=admin_user.id)
+    db.add(parent)
+    db.flush()
+    child = BudgetData(fiscal_year="FY2026", category="Salaries", amount=60000.00, description=None, parent_category_id=parent.id, display_order=2, updated_by=admin_user.id)
+    db.add(child)
+    db.commit()
+    ids = (parent.id, child.id)
+    db.close()
+    return ids
+
+
+def _clear():
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def write_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_engine_with_ids():
+    engine = _make_engine()
+    ids = _seed(engine)
+    yield engine, ids
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_admin_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+_CREATE_PAYLOAD = {
+    "fiscal_year": "FY2026",
+    "category": "Supplies",
+    "amount": 5000.00,
+    "description": "Office supplies",
+    "parent_category_id": None,
+    "display_order": 10,
+}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/budget
+# ---------------------------------------------------------------------------
+
+
+class TestListAdminBudget:
+    def test_returns_200(self, write_admin_client):
+        assert write_admin_client.get("/api/admin/budget").status_code == 200
+
+    def test_returns_list(self, write_admin_client):
+        data = write_admin_client.get("/api/admin/budget").json()
+        assert isinstance(data, list)
+        assert len(data) >= 2
+
+    def test_fiscal_year_filter(self, write_admin_client):
+        data = write_admin_client.get("/api/admin/budget?fiscal_year=FY2026").json()
+        assert all(r["fiscal_year"] == "FY2026" for r in data)
+
+    def test_unknown_fiscal_year_returns_empty(self, write_admin_client):
+        data = write_admin_client.get("/api/admin/budget?fiscal_year=FY1900").json()
+        assert data == []
+
+    def test_response_shape(self, write_admin_client):
+        item = write_admin_client.get("/api/admin/budget").json()[0]
+        for key in ("id", "fiscal_year", "category", "amount", "display_order"):
+            assert key in item
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.get("/api/admin/budget").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/budget
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAdminBudget:
+    def test_returns_201(self, write_admin_client):
+        assert write_admin_client.post("/api/admin/budget", json=_CREATE_PAYLOAD).status_code == 201
+
+    def test_response_contains_id(self, write_admin_client):
+        assert "id" in write_admin_client.post("/api/admin/budget", json=_CREATE_PAYLOAD).json()
+
+    def test_invalid_parent_returns_404(self, write_admin_client):
+        bad = {**_CREATE_PAYLOAD, "parent_category_id": 999999}
+        assert write_admin_client.post("/api/admin/budget", json=bad).status_code == 404
+
+    def test_zero_amount_returns_422(self, write_admin_client):
+        bad = {**_CREATE_PAYLOAD, "amount": 0}
+        assert write_admin_client.post("/api/admin/budget", json=bad).status_code == 422
+
+    def test_missing_required_field_returns_422(self, write_admin_client):
+        bad = {k: v for k, v in _CREATE_PAYLOAD.items() if k != "fiscal_year"}
+        assert write_admin_client.post("/api/admin/budget", json=bad).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/budget/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAdminBudget:
+    def _create_entry(self, client) -> int:
+        return client.post("/api/admin/budget", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_200(self, write_admin_client):
+        entry_id = self._create_entry(write_admin_client)
+        assert write_admin_client.put(f"/api/admin/budget/{entry_id}", json={"category": "Updated"}).status_code == 200
+
+    def test_fields_updated(self, write_admin_client):
+        entry_id = self._create_entry(write_admin_client)
+        resp = write_admin_client.put(f"/api/admin/budget/{entry_id}", json={"category": "Changed"})
+        assert resp.json()["category"] == "Changed"
+
+    def test_self_parent_returns_400(self, write_admin_client):
+        entry_id = self._create_entry(write_admin_client)
+        resp = write_admin_client.put(f"/api/admin/budget/{entry_id}", json={"parent_category_id": entry_id})
+        assert resp.status_code == 400
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/budget/999999", json={"category": "X"}).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/budget/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAdminBudget:
+    def test_returns_204_for_leaf(self, write_engine_with_ids):
+        engine, (parent_id, child_id) = write_engine_with_ids
+        TestSession = sessionmaker(bind=engine)
+
+        def _override_get_db():
+            db = TestSession()
+            try:
+                yield db
+            finally:
+                db.close()
+
+        def _override_current_user():
+            db = TestSession()
+            user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+            db.close()
+            return user
+
+        app.dependency_overrides[get_db] = _override_get_db
+        app.dependency_overrides[get_current_user] = _override_current_user
+        try:
+            with TestClient(app) as c:
+                assert c.delete(f"/api/admin/budget/{child_id}").status_code == 204
+        finally:
+            _clear()
+
+    def test_returns_409_for_parent_with_children(self, write_engine_with_ids):
+        engine, (parent_id, child_id) = write_engine_with_ids
+        TestSession = sessionmaker(bind=engine)
+
+        def _override_get_db():
+            db = TestSession()
+            try:
+                yield db
+            finally:
+                db.close()
+
+        def _override_current_user():
+            db = TestSession()
+            user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+            db.close()
+            return user
+
+        app.dependency_overrides[get_db] = _override_get_db
+        app.dependency_overrides[get_current_user] = _override_current_user
+        try:
+            with TestClient(app) as c:
+                assert c.delete(f"/api/admin/budget/{parent_id}").status_code == 409
+        finally:
+            _clear()
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.delete("/api/admin/budget/999999").status_code == 404

--- a/backend/tests/routes/test_admin_carousel.py
+++ b/backend/tests/routes/test_admin_carousel.py
@@ -1,0 +1,271 @@
+"""Integration tests for admin carousel CRUD routes (ticket #71)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin
+from app.models.base import Base
+from app.models.CarouselSlide import CarouselSlide
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+def _make_engine():
+    engine = create_engine(_SQLITE_URL, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    original = {t: set(t.constraints) for t in Base.metadata.tables.values()}
+    try:
+        for t in Base.metadata.tables.values():
+            t.constraints = {c for c in t.constraints if not isinstance(c, CheckConstraint)}
+        Base.metadata.create_all(bind=engine)
+    finally:
+        for t, constraints in original.items():
+            t.constraints = constraints
+    return engine
+
+
+def _seed(engine) -> list[int]:
+    """Returns the IDs of the seeded slides in insertion order."""
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    db.add(Admin(email="admin@unc.edu", first_name="Admin", last_name="User", pid="100000001", role="admin"))
+    db.flush()
+    s1 = CarouselSlide(image_url="https://img.unc.edu/1.jpg", overlay_text="Slide 1", link_url=None, display_order=1, is_active=True)
+    s2 = CarouselSlide(image_url="https://img.unc.edu/2.jpg", overlay_text="Slide 2", link_url=None, display_order=2, is_active=True)
+    s3 = CarouselSlide(image_url="https://img.unc.edu/3.jpg", overlay_text="Slide 3", link_url=None, display_order=3, is_active=False)
+    db.add_all([s1, s2, s3])
+    db.commit()
+    ids = [s1.id, s2.id, s3.id]
+    db.close()
+    return ids
+
+
+def _clear():
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def write_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_engine_with_ids():
+    engine = _make_engine()
+    ids = _seed(engine)
+    yield engine, ids
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_admin_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+_CREATE_PAYLOAD = {
+    "image_url": "https://img.unc.edu/new.jpg",
+    "overlay_text": "New Slide",
+    "link_url": "https://unc.edu",
+    "display_order": 4,
+    "is_active": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/carousel
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAdminSlide:
+    def test_returns_201(self, write_admin_client):
+        assert write_admin_client.post("/api/admin/carousel", json=_CREATE_PAYLOAD).status_code == 201
+
+    def test_response_shape(self, write_admin_client):
+        resp = write_admin_client.post("/api/admin/carousel", json=_CREATE_PAYLOAD).json()
+        for key in ("id", "image_url", "display_order", "is_active"):
+            assert key in resp
+
+    def test_missing_required_field_returns_422(self, write_admin_client):
+        bad = {k: v for k, v in _CREATE_PAYLOAD.items() if k != "image_url"}
+        assert write_admin_client.post("/api/admin/carousel", json=bad).status_code == 422
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.post("/api/admin/carousel", json=_CREATE_PAYLOAD).status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/carousel/reorder
+# ---------------------------------------------------------------------------
+
+
+class TestReorderAdminSlides:
+    def test_returns_200(self, write_engine_with_ids):
+        engine, ids = write_engine_with_ids
+        TestSession = sessionmaker(bind=engine)
+
+        def _override_get_db():
+            db = TestSession()
+            try:
+                yield db
+            finally:
+                db.close()
+
+        def _override_current_user():
+            db = TestSession()
+            user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+            db.close()
+            return user
+
+        app.dependency_overrides[get_db] = _override_get_db
+        app.dependency_overrides[get_current_user] = _override_current_user
+        try:
+            with TestClient(app) as c:
+                resp = c.put("/api/admin/carousel/reorder", json={"slide_ids": ids})
+                assert resp.status_code == 200
+        finally:
+            _clear()
+
+    def test_reorder_changes_order(self, write_engine_with_ids):
+        engine, ids = write_engine_with_ids
+        TestSession = sessionmaker(bind=engine)
+        reversed_ids = list(reversed(ids))
+
+        def _override_get_db():
+            db = TestSession()
+            try:
+                yield db
+            finally:
+                db.close()
+
+        def _override_current_user():
+            db = TestSession()
+            user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+            db.close()
+            return user
+
+        app.dependency_overrides[get_db] = _override_get_db
+        app.dependency_overrides[get_current_user] = _override_current_user
+        try:
+            with TestClient(app) as c:
+                resp = c.put("/api/admin/carousel/reorder", json={"slide_ids": reversed_ids})
+                assert resp.status_code == 200
+                result_ids = [s["id"] for s in resp.json()]
+                assert result_ids == reversed_ids
+        finally:
+            _clear()
+
+    def test_partial_ids_returns_400(self, write_engine_with_ids):
+        engine, ids = write_engine_with_ids
+        TestSession = sessionmaker(bind=engine)
+
+        def _override_get_db():
+            db = TestSession()
+            try:
+                yield db
+            finally:
+                db.close()
+
+        def _override_current_user():
+            db = TestSession()
+            user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+            db.close()
+            return user
+
+        app.dependency_overrides[get_db] = _override_get_db
+        app.dependency_overrides[get_current_user] = _override_current_user
+        try:
+            with TestClient(app) as c:
+                resp = c.put("/api/admin/carousel/reorder", json={"slide_ids": ids[:-1]})
+                assert resp.status_code == 400
+        finally:
+            _clear()
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/carousel/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAdminSlide:
+    def _create_slide(self, client) -> int:
+        return client.post("/api/admin/carousel", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_200(self, write_admin_client):
+        slide_id = self._create_slide(write_admin_client)
+        assert write_admin_client.put(f"/api/admin/carousel/{slide_id}", json={"is_active": False}).status_code == 200
+
+    def test_fields_updated(self, write_admin_client):
+        slide_id = self._create_slide(write_admin_client)
+        resp = write_admin_client.put(f"/api/admin/carousel/{slide_id}", json={"overlay_text": "Changed"})
+        assert resp.json()["overlay_text"] == "Changed"
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/carousel/999999", json={"is_active": False}).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/carousel/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAdminSlide:
+    def _create_slide(self, client) -> int:
+        return client.post("/api/admin/carousel", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_204(self, write_admin_client):
+        slide_id = self._create_slide(write_admin_client)
+        assert write_admin_client.delete(f"/api/admin/carousel/{slide_id}").status_code == 204
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.delete("/api/admin/carousel/999999").status_code == 404
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.delete("/api/admin/carousel/1").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved

--- a/backend/tests/routes/test_admin_districts.py
+++ b/backend/tests/routes/test_admin_districts.py
@@ -1,0 +1,257 @@
+"""Integration tests for admin district CRUD routes (ticket #71)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin, Senator
+from app.models.base import Base
+from app.models.District import District
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+def _make_engine():
+    engine = create_engine(_SQLITE_URL, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    original = {t: set(t.constraints) for t in Base.metadata.tables.values()}
+    try:
+        for t in Base.metadata.tables.values():
+            t.constraints = {c for c in t.constraints if not isinstance(c, CheckConstraint)}
+        Base.metadata.create_all(bind=engine)
+    finally:
+        for t, constraints in original.items():
+            t.constraints = constraints
+    return engine
+
+
+def _seed(engine) -> int:
+    """Returns the ID of the seeded district."""
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    db.add(Admin(email="admin@unc.edu", first_name="Admin", last_name="User", pid="100000001", role="admin"))
+    db.flush()
+    d = District(district_name="On-Campus", description="On-campus students")
+    db.add(d)
+    db.commit()
+    district_id = d.id
+    db.close()
+    return district_id
+
+
+def _seed_with_senator(engine) -> tuple[int, int]:
+    """Returns (district_id, senator_id) for FK constraint testing."""
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    db.add(Admin(email="admin@unc.edu", first_name="Admin", last_name="User", pid="100000001", role="admin"))
+    db.flush()
+    d = District(district_name="Locked District", description=None)
+    db.add(d)
+    db.flush()
+    s = Senator(first_name="Alice", last_name="Smith", email="asmith@unc.edu", district=d.id, is_active=True, session_number=35)
+    db.add(s)
+    db.commit()
+    ids = (d.id, s.id)
+    db.close()
+    return ids
+
+
+def _clear():
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture(scope="module")
+def read_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def admin_read_client(read_engine):
+    TestSession = sessionmaker(bind=read_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+@pytest.fixture()
+def write_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_admin_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+_CREATE_PAYLOAD = {"district_name": "Graduate Students", "description": "Graduate student district"}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/districts
+# ---------------------------------------------------------------------------
+
+
+class TestListAdminDistricts:
+    def test_returns_200(self, admin_read_client):
+        assert admin_read_client.get("/api/admin/districts").status_code == 200
+
+    def test_returns_list(self, admin_read_client):
+        data = admin_read_client.get("/api/admin/districts").json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+
+    def test_response_shape(self, admin_read_client):
+        item = admin_read_client.get("/api/admin/districts").json()[0]
+        for key in ("id", "district_name", "description"):
+            assert key in item
+
+    def test_no_senator_field(self, admin_read_client):
+        item = admin_read_client.get("/api/admin/districts").json()[0]
+        assert "senator" not in item
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.get("/api/admin/districts").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/districts
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAdminDistrict:
+    def test_returns_201(self, write_admin_client):
+        assert write_admin_client.post("/api/admin/districts", json=_CREATE_PAYLOAD).status_code == 201
+
+    def test_response_shape(self, write_admin_client):
+        resp = write_admin_client.post("/api/admin/districts", json=_CREATE_PAYLOAD).json()
+        for key in ("id", "district_name", "description"):
+            assert key in resp
+
+    def test_missing_name_returns_422(self, write_admin_client):
+        assert write_admin_client.post("/api/admin/districts", json={"description": "No name"}).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/districts/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAdminDistrict:
+    def _create_district(self, client) -> int:
+        return client.post("/api/admin/districts", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_200(self, write_admin_client):
+        district_id = self._create_district(write_admin_client)
+        assert write_admin_client.put(f"/api/admin/districts/{district_id}", json={"district_name": "Updated"}).status_code == 200
+
+    def test_fields_updated(self, write_admin_client):
+        district_id = self._create_district(write_admin_client)
+        resp = write_admin_client.put(f"/api/admin/districts/{district_id}", json={"district_name": "Changed"})
+        assert resp.json()["district_name"] == "Changed"
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/districts/999999", json={"district_name": "X"}).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/districts/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAdminDistrict:
+    def _create_district(self, client) -> int:
+        return client.post("/api/admin/districts", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_204(self, write_admin_client):
+        district_id = self._create_district(write_admin_client)
+        assert write_admin_client.delete(f"/api/admin/districts/{district_id}").status_code == 204
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.delete("/api/admin/districts/999999").status_code == 404
+
+    def test_returns_409_when_senator_linked(self):
+        engine = _make_engine()
+        district_id, _ = _seed_with_senator(engine)
+        TestSession = sessionmaker(bind=engine)
+
+        def _override_get_db():
+            db = TestSession()
+            try:
+                yield db
+            finally:
+                db.close()
+
+        def _override_current_user():
+            db = TestSession()
+            user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+            db.close()
+            return user
+
+        app.dependency_overrides[get_db] = _override_get_db
+        app.dependency_overrides[get_current_user] = _override_current_user
+        try:
+            with TestClient(app) as c:
+                assert c.delete(f"/api/admin/districts/{district_id}").status_code == 409
+        finally:
+            _clear()
+            Base.metadata.drop_all(bind=engine)

--- a/backend/tests/routes/test_admin_events.py
+++ b/backend/tests/routes/test_admin_events.py
@@ -1,0 +1,247 @@
+"""Integration tests for admin calendar event CRUD routes (ticket #71)."""
+
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin
+from app.models.base import Base
+from app.models.CalendarEvent import CalendarEvent
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+def _make_engine():
+    engine = create_engine(
+        _SQLITE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    original = {t: set(t.constraints) for t in Base.metadata.tables.values()}
+    try:
+        for t in Base.metadata.tables.values():
+            t.constraints = {c for c in t.constraints if not isinstance(c, CheckConstraint)}
+        Base.metadata.create_all(bind=engine)
+    finally:
+        for t, constraints in original.items():
+            t.constraints = constraints
+    return engine
+
+
+def _seed(engine):
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    admin_user = Admin(email="admin@unc.edu", first_name="Admin", last_name="User", pid="100000001", role="admin")
+    staff_user = Admin(email="staff@unc.edu", first_name="Staff", last_name="User", pid="200000002", role="staff")
+    db.add_all([admin_user, staff_user])
+    db.flush()
+    db.add(CalendarEvent(
+        title="Existing Event",
+        start_datetime=datetime(2026, 4, 1, 18, 0),
+        end_datetime=datetime(2026, 4, 1, 19, 0),
+        event_type="meeting",
+        is_published=True,
+        created_by=admin_user.id,
+        description=None,
+        location=None,
+    ))
+    db.commit()
+    db.close()
+
+
+def _clear():
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+# ---------------------------------------------------------------------------
+# Function-scoped fixtures (write tests)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def write_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_admin_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+@pytest.fixture()
+def write_staff_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "staff@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/events
+# ---------------------------------------------------------------------------
+
+_CREATE_PAYLOAD = {
+    "title": "New Event",
+    "description": "A test event",
+    "start_datetime": "2026-06-01T10:00:00",
+    "end_datetime": "2026-06-01T11:00:00",
+    "location": "Chapel Hill",
+    "event_type": "meeting",
+    "is_published": False,
+}
+
+
+class TestCreateAdminEvent:
+    def test_returns_201(self, write_admin_client):
+        assert write_admin_client.post("/api/admin/events", json=_CREATE_PAYLOAD).status_code == 201
+
+    def test_response_contains_id_and_is_published(self, write_admin_client):
+        resp = write_admin_client.post("/api/admin/events", json=_CREATE_PAYLOAD).json()
+        assert "id" in resp
+        assert "is_published" in resp
+
+    def test_is_published_true(self, write_admin_client):
+        resp = write_admin_client.post("/api/admin/events", json={**_CREATE_PAYLOAD, "is_published": True})
+        assert resp.json()["is_published"] is True
+
+    def test_end_before_start_returns_422(self, write_admin_client):
+        bad = {**_CREATE_PAYLOAD, "end_datetime": "2026-06-01T09:00:00"}
+        assert write_admin_client.post("/api/admin/events", json=bad).status_code == 422
+
+    def test_missing_title_returns_422(self, write_admin_client):
+        bad = {k: v for k, v in _CREATE_PAYLOAD.items() if k != "title"}
+        assert write_admin_client.post("/api/admin/events", json=bad).status_code == 422
+
+    def test_staff_can_create(self, write_staff_client):
+        assert write_staff_client.post("/api/admin/events", json=_CREATE_PAYLOAD).status_code == 201
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.post("/api/admin/events", json=_CREATE_PAYLOAD).status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/events/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAdminEvent:
+    def _create_event(self, client) -> int:
+        return client.post("/api/admin/events", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_200(self, write_admin_client):
+        event_id = self._create_event(write_admin_client)
+        assert write_admin_client.put(f"/api/admin/events/{event_id}", json={"title": "Updated"}).status_code == 200
+
+    def test_fields_updated(self, write_admin_client):
+        event_id = self._create_event(write_admin_client)
+        resp = write_admin_client.put(
+            f"/api/admin/events/{event_id}",
+            json={"title": "Changed", "is_published": True},
+        )
+        assert resp.json()["title"] == "Changed"
+        assert resp.json()["is_published"] is True
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/events/999999", json={"title": "X"}).status_code == 404
+
+    def test_staff_can_update(self, write_staff_client):
+        event_id = self._create_event(write_staff_client)
+        assert write_staff_client.put(f"/api/admin/events/{event_id}", json={"title": "Staff"}).status_code == 200
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.put("/api/admin/events/1", json={"title": "X"}).status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/events/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAdminEvent:
+    def _create_event(self, client) -> int:
+        return client.post("/api/admin/events", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_204(self, write_admin_client):
+        event_id = self._create_event(write_admin_client)
+        assert write_admin_client.delete(f"/api/admin/events/{event_id}").status_code == 204
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.delete("/api/admin/events/999999").status_code == 404
+
+    def test_staff_cannot_delete(self, write_staff_client):
+        event_id = self._create_event(write_staff_client)
+        assert write_staff_client.delete(f"/api/admin/events/{event_id}").status_code == 403
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.delete("/api/admin/events/1").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved

--- a/backend/tests/routes/test_admin_finance.py
+++ b/backend/tests/routes/test_admin_finance.py
@@ -1,0 +1,215 @@
+"""Integration tests for admin finance hearing CRUD routes (ticket #71)."""
+
+from datetime import date, time
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin
+from app.models.base import Base
+from app.models.FinanceHearingConfig import FinanceHearingConfig
+from app.models.FinanceHearingDate import FinanceHearingDate
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+def _make_engine():
+    engine = create_engine(_SQLITE_URL, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    original = {t: set(t.constraints) for t in Base.metadata.tables.values()}
+    try:
+        for t in Base.metadata.tables.values():
+            t.constraints = {c for c in t.constraints if not isinstance(c, CheckConstraint)}
+        Base.metadata.create_all(bind=engine)
+    finally:
+        for t, constraints in original.items():
+            t.constraints = constraints
+    return engine
+
+
+def _seed(engine):
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    admin_user = Admin(email="admin@unc.edu", first_name="Admin", last_name="User", pid="100000001", role="admin")
+    db.add(admin_user)
+    db.flush()
+    config = FinanceHearingConfig(
+        is_active=True,
+        season_start=date(2026, 1, 1),
+        season_end=date(2026, 5, 31),
+        updated_by=admin_user.id,
+    )
+    db.add(config)
+    db.flush()
+    db.add(FinanceHearingDate(
+        hearing_date=date(2026, 2, 10),
+        hearing_time=time(9, 0),
+        location="The Pit",
+        description="Morning slot",
+        is_full=False,
+    ))
+    db.commit()
+    db.close()
+
+
+def _clear():
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def write_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_admin_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/finance-hearings/config
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateFinanceConfig:
+    _payload = {"is_active": False, "season_start": "2026-03-01", "season_end": "2026-06-30"}
+
+    def test_returns_200(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/finance-hearings/config", json=self._payload).status_code == 200
+
+    def test_config_updated(self, write_admin_client):
+        resp = write_admin_client.put("/api/admin/finance-hearings/config", json=self._payload)
+        assert resp.json()["is_active"] is False
+        assert resp.json()["season_start"] == "2026-03-01"
+
+    def test_inactive_config_returns_empty_dates(self, write_admin_client):
+        resp = write_admin_client.put("/api/admin/finance-hearings/config", json={**self._payload, "is_active": False})
+        assert resp.json()["dates"] == []
+
+    def test_active_config_returns_dates(self, write_admin_client):
+        resp = write_admin_client.put("/api/admin/finance-hearings/config", json={**self._payload, "is_active": True})
+        assert isinstance(resp.json()["dates"], list)
+
+    def test_missing_required_field_returns_422(self, write_admin_client):
+        bad = {"season_start": "2026-03-01", "season_end": "2026-06-30"}
+        assert write_admin_client.put("/api/admin/finance-hearings/config", json=bad).status_code == 422
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.put("/api/admin/finance-hearings/config", json=self._payload).status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/finance-hearings/dates
+# ---------------------------------------------------------------------------
+
+_DATE_PAYLOAD = {
+    "hearing_date": "2026-03-15",
+    "hearing_time": "10:00:00",
+    "location": "Union",
+    "description": "Afternoon slot",
+}
+
+
+class TestCreateFinanceDate:
+    def test_returns_201(self, write_admin_client):
+        assert write_admin_client.post("/api/admin/finance-hearings/dates", json=_DATE_PAYLOAD).status_code == 201
+
+    def test_response_shape(self, write_admin_client):
+        resp = write_admin_client.post("/api/admin/finance-hearings/dates", json=_DATE_PAYLOAD).json()
+        for key in ("id", "hearing_date", "hearing_time", "is_full"):
+            assert key in resp
+
+    def test_missing_required_field_returns_422(self, write_admin_client):
+        bad = {k: v for k, v in _DATE_PAYLOAD.items() if k != "hearing_date"}
+        assert write_admin_client.post("/api/admin/finance-hearings/dates", json=bad).status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/finance-hearings/dates/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateFinanceDate:
+    def _create_date(self, client) -> int:
+        return client.post("/api/admin/finance-hearings/dates", json=_DATE_PAYLOAD).json()["id"]
+
+    def test_returns_200(self, write_admin_client):
+        date_id = self._create_date(write_admin_client)
+        assert write_admin_client.put(f"/api/admin/finance-hearings/dates/{date_id}", json={"is_full": True}).status_code == 200
+
+    def test_fields_updated(self, write_admin_client):
+        date_id = self._create_date(write_admin_client)
+        resp = write_admin_client.put(f"/api/admin/finance-hearings/dates/{date_id}", json={"is_full": True, "location": "Changed"})
+        assert resp.json()["is_full"] is True
+        assert resp.json()["location"] == "Changed"
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/finance-hearings/dates/999999", json={"is_full": True}).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/finance-hearings/dates/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteFinanceDate:
+    def _create_date(self, client) -> int:
+        return client.post("/api/admin/finance-hearings/dates", json=_DATE_PAYLOAD).json()["id"]
+
+    def test_returns_204(self, write_admin_client):
+        date_id = self._create_date(write_admin_client)
+        assert write_admin_client.delete(f"/api/admin/finance-hearings/dates/{date_id}").status_code == 204
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.delete("/api/admin/finance-hearings/dates/999999").status_code == 404
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.delete("/api/admin/finance-hearings/dates/1").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved

--- a/backend/tests/routes/test_admin_pages.py
+++ b/backend/tests/routes/test_admin_pages.py
@@ -1,0 +1,190 @@
+"""Integration tests for admin static pages routes (ticket #71)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin
+from app.models.base import Base
+from app.models.cms import StaticPageContent
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+def _make_engine():
+    engine = create_engine(_SQLITE_URL, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    original = {t: set(t.constraints) for t in Base.metadata.tables.values()}
+    try:
+        for t in Base.metadata.tables.values():
+            t.constraints = {c for c in t.constraints if not isinstance(c, CheckConstraint)}
+        Base.metadata.create_all(bind=engine)
+    finally:
+        for t, constraints in original.items():
+            t.constraints = constraints
+    return engine
+
+
+def _seed(engine):
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    admin_user = Admin(email="admin@unc.edu", first_name="Admin", last_name="User", pid="100000001", role="admin")
+    db.add(admin_user)
+    db.flush()
+    db.add_all([
+        StaticPageContent(page_slug="powers-of-senate", title="Powers of the Senate", body="The senate has...", last_edited_by=admin_user.id),
+        StaticPageContent(page_slug="how-a-bill-becomes-law", title="How a Bill Becomes Law", body="A bill starts as...", last_edited_by=admin_user.id),
+    ])
+    db.commit()
+    db.close()
+
+
+def _clear():
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture(scope="module")
+def read_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def admin_read_client(read_engine):
+    TestSession = sessionmaker(bind=read_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+@pytest.fixture()
+def write_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_admin_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admin/pages
+# ---------------------------------------------------------------------------
+
+
+class TestListAdminPages:
+    def test_returns_200(self, admin_read_client):
+        assert admin_read_client.get("/api/admin/pages").status_code == 200
+
+    def test_returns_list_of_pages(self, admin_read_client):
+        data = admin_read_client.get("/api/admin/pages").json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+
+    def test_response_shape(self, admin_read_client):
+        item = admin_read_client.get("/api/admin/pages").json()[0]
+        for key in ("id", "page_slug", "title", "body", "updated_at"):
+            assert key in item
+
+    def test_slugs_present(self, admin_read_client):
+        slugs = {p["page_slug"] for p in admin_read_client.get("/api/admin/pages").json()}
+        assert "powers-of-senate" in slugs
+        assert "how-a-bill-becomes-law" in slugs
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.get("/api/admin/pages").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/pages/{slug}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAdminPage:
+    _payload = {"title": "Updated Title", "body": "Updated body content."}
+
+    def test_returns_200(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/pages/powers-of-senate", json=self._payload).status_code == 200
+
+    def test_fields_updated(self, write_admin_client):
+        resp = write_admin_client.put("/api/admin/pages/powers-of-senate", json=self._payload)
+        assert resp.json()["title"] == "Updated Title"
+        assert resp.json()["body"] == "Updated body content."
+
+    def test_slug_unchanged(self, write_admin_client):
+        resp = write_admin_client.put("/api/admin/pages/powers-of-senate", json=self._payload)
+        assert resp.json()["page_slug"] == "powers-of-senate"
+
+    def test_returns_404_for_unknown_slug(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/pages/nonexistent-page", json=self._payload).status_code == 404
+
+    def test_missing_required_field_returns_422(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/pages/powers-of-senate", json={"title": "Only Title"}).status_code == 422
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.put("/api/admin/pages/powers-of-senate", json=self._payload).status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved

--- a/backend/tests/routes/test_admin_staff.py
+++ b/backend/tests/routes/test_admin_staff.py
@@ -1,0 +1,185 @@
+"""Integration tests for admin staff CRUD routes (ticket #71)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin
+from app.models.base import Base
+from app.models.cms import Staff
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+def _make_engine():
+    engine = create_engine(_SQLITE_URL, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    original = {t: set(t.constraints) for t in Base.metadata.tables.values()}
+    try:
+        for t in Base.metadata.tables.values():
+            t.constraints = {c for c in t.constraints if not isinstance(c, CheckConstraint)}
+        Base.metadata.create_all(bind=engine)
+    finally:
+        for t, constraints in original.items():
+            t.constraints = constraints
+    return engine
+
+
+def _seed(engine):
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    db.add_all([
+        Admin(email="admin@unc.edu", first_name="Admin", last_name="User", pid="100000001", role="admin"),
+        Admin(email="staff@unc.edu", first_name="Staff", last_name="User", pid="200000002", role="staff"),
+    ])
+    db.flush()
+    db.add(Staff(first_name="Existing", last_name="Person", title="Director", email="existing@unc.edu", display_order=1))
+    db.commit()
+    db.close()
+
+
+def _clear():
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def write_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_admin_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+_CREATE_PAYLOAD = {
+    "first_name": "New",
+    "last_name": "Staffer",
+    "title": "Coordinator",
+    "email": "newstaffer@unc.edu",
+    "display_order": 5,
+}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/admin/staff
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAdminStaff:
+    def test_returns_201(self, write_admin_client):
+        assert write_admin_client.post("/api/admin/staff", json=_CREATE_PAYLOAD).status_code == 201
+
+    def test_response_shape(self, write_admin_client):
+        resp = write_admin_client.post("/api/admin/staff", json=_CREATE_PAYLOAD).json()
+        for key in ("id", "first_name", "last_name", "title", "email"):
+            assert key in resp
+
+    def test_missing_required_field_returns_422(self, write_admin_client):
+        bad = {k: v for k, v in _CREATE_PAYLOAD.items() if k != "email"}
+        assert write_admin_client.post("/api/admin/staff", json=bad).status_code == 422
+
+    def test_invalid_email_returns_422(self, write_admin_client):
+        bad = {**_CREATE_PAYLOAD, "email": "not-an-email"}
+        assert write_admin_client.post("/api/admin/staff", json=bad).status_code == 422
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.post("/api/admin/staff", json=_CREATE_PAYLOAD).status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admin/staff/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAdminStaff:
+    def _create_staff(self, client) -> int:
+        return client.post("/api/admin/staff", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_200(self, write_admin_client):
+        staff_id = self._create_staff(write_admin_client)
+        assert write_admin_client.put(f"/api/admin/staff/{staff_id}", json={"title": "Updated"}).status_code == 200
+
+    def test_fields_updated(self, write_admin_client):
+        staff_id = self._create_staff(write_admin_client)
+        resp = write_admin_client.put(f"/api/admin/staff/{staff_id}", json={"title": "Manager", "is_active": False})
+        assert resp.json()["title"] == "Manager"
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.put("/api/admin/staff/999999", json={"title": "X"}).status_code == 404
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.put("/api/admin/staff/1", json={"title": "X"}).status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admin/staff/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAdminStaff:
+    def _create_staff(self, client) -> int:
+        return client.post("/api/admin/staff", json=_CREATE_PAYLOAD).json()["id"]
+
+    def test_returns_204(self, write_admin_client):
+        staff_id = self._create_staff(write_admin_client)
+        assert write_admin_client.delete(f"/api/admin/staff/{staff_id}").status_code == 204
+
+    def test_returns_404_for_missing(self, write_admin_client):
+        assert write_admin_client.delete("/api/admin/staff/999999").status_code == 404
+
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.delete("/api/admin/staff/1").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved


### PR DESCRIPTION
Implements the remaining admin CRUD API routes needed to support the admin dashboard. These are the backend endpoints that staff and admins will use to manage events, carousel slides, staff members, finance hearings, budget data, static pages, districts, and accounts.

Changes:

- Added POST/PUT/DELETE /api/admin/events to create, edit, and delete calendar events; DELETE is restricted to admin role   
- Added POST/PUT/DELETE /api/admin/carousel and PUT /api/admin/carousel/reorder to manage and batch-reorder homepage carousel slides
- Added POST/PUT/DELETE /api/admin/staff to manage staff directory entries
- Added PUT /api/admin/finance-hearings/config to update the singleton hearing config and POST/PUT/DELETE                   
/api/admin/finance-hearings/dates to manage individual hearing date slots
- Added GET/POST/PUT/DELETE /api/admin/budget for flat budget entry management; DELETE is blocked if the entry has children
- Added GET /api/admin/pages and PUT /api/admin/pages/{slug} for listing and editing pre-seeded static pages                
- Added GET/POST/PUT/DELETE /api/admin/districts; DELETE is blocked if senators are still assigned to the district          
- Added GET/POST/PUT/DELETE /api/admin/accounts restricted to admin role only; admins cannot delete their own account       
- Added missing update/create DTOs (UpdateStaffDTO, UpdateBudgetDataDTO, AdminDistrictDTO, etc.) and registered all new routers in main.py
- Added 120 integration tests across 8 test files covering happy paths, 404s, role enforcement, and validation errors
                                                                 
  Closes #71 