### PR TITLE
Admin Staff, Accounts, Districts, and Static Pages management (#98)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.routers.admin import accounts as admin_accounts
 from app.routers.admin import budget as admin_budget
 from app.routers.admin import carousel as admin_carousel
 from app.routers.admin import committees as admin_committees
+from app.routers.admin import district_mapping as admin_district_mapping
 from app.routers.admin import districts as admin_districts
 from app.routers.admin import events as admin_events
 from app.routers.admin import finance as admin_finance
@@ -80,6 +81,7 @@ app.include_router(admin_finance.router)
 app.include_router(admin_budget.router)
 app.include_router(admin_pages.router)
 app.include_router(admin_districts.router)
+app.include_router(admin_district_mapping.router)
 app.include_router(admin_accounts.router)
 
 

--- a/backend/app/routers/admin/district_mapping.py
+++ b/backend/app/routers/admin/district_mapping.py
@@ -1,0 +1,92 @@
+"""Admin district mapping CRUD routes.
+
+GET    /api/admin/districts/{district_id}/mappings          — list mappings for a district
+POST   /api/admin/districts/{district_id}/mappings          — create mapping for a district
+DELETE /api/admin/districts/{district_id}/mappings/{map_id} — delete a mapping
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.Admin import Admin
+from app.models.District import District, DistrictMapping
+from app.schemas.district import CreateDistrictMappingDTO, DistrictMappingDTO
+
+router = APIRouter(
+    prefix="/api/admin/districts",
+    tags=["admin", "districts"],
+)
+
+
+@router.get("/{district_id}/mappings", response_model=list[DistrictMappingDTO])
+def list_district_mappings(
+    district_id: int,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return all mappings for a district."""
+    district = db.query(District).filter(District.id == district_id).first()
+    if district is None:
+        raise HTTPException(status_code=404, detail="District not found")
+
+    mappings = db.query(DistrictMapping).filter(
+        DistrictMapping.district_id == district_id
+    ).all()
+    return [DistrictMappingDTO.model_validate(m) for m in mappings]
+
+
+@router.post(
+    "/{district_id}/mappings",
+    response_model=DistrictMappingDTO,
+    status_code=status.HTTP_201_CREATED,
+    responses={404: {"description": "District not found"}},
+)
+def create_district_mapping(
+    district_id: int,
+    body: CreateDistrictMappingDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a mapping for a district."""
+    district = db.query(District).filter(District.id == district_id).first()
+    if district is None:
+        raise HTTPException(status_code=404, detail="District not found")
+
+    mapping = DistrictMapping(
+        district_id=district_id,
+        mapping_value=body.mapping_value,
+    )
+    db.add(mapping)
+    db.commit()
+    db.refresh(mapping)
+    return DistrictMappingDTO.model_validate(mapping)
+
+
+@router.delete(
+    "/{district_id}/mappings/{map_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={404: {"description": "District or mapping not found"}},
+)
+def delete_district_mapping(
+    district_id: int,
+    map_id: int,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Delete a mapping from a district."""
+    district = db.query(District).filter(District.id == district_id).first()
+    if district is None:
+        raise HTTPException(status_code=404, detail="District not found")
+
+    mapping = db.query(DistrictMapping).filter(
+        DistrictMapping.id == map_id,
+        DistrictMapping.district_id == district_id,
+    ).first()
+    if mapping is None:
+        raise HTTPException(status_code=404, detail="Mapping not found")
+
+    db.delete(mapping)
+    db.commit()
+    return None

--- a/backend/app/routers/admin/pages.py
+++ b/backend/app/routers/admin/pages.py
@@ -12,6 +12,7 @@ from app.dependencies.auth import get_current_user
 from app.models.Admin import Admin
 from app.models.cms import StaticPageContent
 from app.schemas.static_page import StaticPageDTO, UpdateStaticPageDTO
+from app.utils.sanitization import sanitize_html
 
 router = APIRouter(
     prefix="/api/admin/pages",
@@ -46,7 +47,7 @@ def update_admin_page(
         raise HTTPException(status_code=404, detail="Page not found")
 
     page.title = body.title
-    page.body = body.body
+    page.body = sanitize_html(body.body)
     page.last_edited_by = current_user.id
 
     db.commit()

--- a/backend/app/routers/admin/staff.py
+++ b/backend/app/routers/admin/staff.py
@@ -1,0 +1,88 @@
+"""Admin staff CRUD routes.
+
+POST   /api/admin/staff       — create staff member
+PUT    /api/admin/staff/{id}  — update staff fields
+DELETE /api/admin/staff/{id}  — delete staff member
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.Admin import Admin
+from app.models.cms import Staff
+from app.schemas.staff import AdminStaffDTO, CreateStaffDTO, StaffDTO, UpdateStaffDTO
+
+router = APIRouter(
+    prefix="/api/admin/staff",
+    tags=["admin", "staff"],
+)
+
+
+@router.get("", response_model=list[AdminStaffDTO])
+def list_admin_staff(
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return all staff members ordered by display_order."""
+    staff = db.query(Staff).order_by(Staff.display_order, Staff.last_name).all()
+    return [AdminStaffDTO.model_validate(s) for s in staff]
+
+
+@router.post("", response_model=StaffDTO, status_code=status.HTTP_201_CREATED)
+def create_admin_staff(
+    body: CreateStaffDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a staff member."""
+    staff = Staff(**body.model_dump())
+    db.add(staff)
+    db.commit()
+    db.refresh(staff)
+    return StaffDTO.model_validate(staff)
+
+
+@router.put(
+    "/{staff_id}",
+    response_model=StaffDTO,
+    responses={404: {"description": "Staff member not found"}},
+)
+def update_admin_staff(
+    staff_id: int,
+    body: UpdateStaffDTO,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update staff fields. Unset fields remain unchanged."""
+    staff = db.query(Staff).filter(Staff.id == staff_id).first()
+    if staff is None:
+        raise HTTPException(status_code=404, detail="Staff member not found")
+
+    for field, value in body.model_dump(exclude_unset=True).items():
+        setattr(staff, field, value)
+
+    db.commit()
+    db.refresh(staff)
+    return StaffDTO.model_validate(staff)
+
+
+@router.delete(
+    "/{staff_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={404: {"description": "Staff member not found"}},
+)
+def delete_admin_staff(
+    staff_id: int,
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Delete a staff member."""
+    staff = db.query(Staff).filter(Staff.id == staff_id).first()
+    if staff is None:
+        raise HTTPException(status_code=404, detail="Staff member not found")
+
+    db.delete(staff)
+    db.commit()
+    return None

--- a/backend/app/schemas/district.py
+++ b/backend/app/schemas/district.py
@@ -34,3 +34,24 @@ class CreateDistrictDTO(BaseModel):
 class UpdateDistrictDTO(BaseModel):
     district_name: str | None = None
     description: str | None = None
+
+
+class DistrictMappingDTO(BaseModel):
+    id: int
+    district_id: int
+    mapping_value: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CreateDistrictMappingDTO(BaseModel):
+    mapping_value: str
+
+
+class AdminDistrictWithMappingsDTO(BaseModel):
+    id: int
+    district_name: str
+    description: str | None
+    mappings: list[DistrictMappingDTO] = []
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/staff.py
+++ b/backend/app/schemas/staff.py
@@ -14,9 +14,32 @@ class StaffDTO(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class AdminStaffDTO(BaseModel):
+    id: int
+    first_name: str
+    last_name: str
+    title: str
+    email: str
+    photo_url: str | None
+    display_order: int
+    is_active: bool
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class CreateStaffDTO(BaseModel):
     first_name: str
     last_name: str
     title: str
     email: EmailStr
     display_order: int
+
+
+class UpdateStaffDTO(BaseModel):
+    first_name: str | None = None
+    last_name: str | None = None
+    title: str | None = None
+    email: EmailStr | None = None
+    photo_url: str | None = None
+    display_order: int | None = None
+    is_active: bool | None = None

--- a/backend/app/utils/sanitization.py
+++ b/backend/app/utils/sanitization.py
@@ -1,0 +1,51 @@
+"""HTML sanitization utilities."""
+
+import bleach
+
+# Allowed HTML tags for rich text content
+ALLOWED_TAGS = [
+    "p",
+    "br",
+    "strong",
+    "em",
+    "u",
+    "ol",
+    "ul",
+    "li",
+    "blockquote",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "a",
+    "img",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "hr",
+    "code",
+    "pre",
+]
+
+# Allowed attributes for HTML tags
+ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title", "target"],
+    "img": ["src", "alt", "title", "width", "height"],
+    "table": ["border", "cellpadding", "cellspacing"],
+}
+
+
+def sanitize_html(content: str) -> str:
+    """
+    Sanitize HTML content to prevent XSS attacks.
+
+    Allows safe HTML tags and attributes commonly used in rich text editors.
+    """
+    if not content:
+        return ""
+    return bleach.clean(content, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, strip=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,5 +20,8 @@ pre-commit==3.7.1
 ruff==0.9.3
 junitparser==3.2.0
 
+# Security & Sanitization
+bleach==6.1.0
+
 # JSON Web Token
 python-jose[cryptography]==3.3.0

--- a/frontend/src/app/admin/accounts/page.tsx
+++ b/frontend/src/app/admin/accounts/page.tsx
@@ -1,3 +1,208 @@
+"use client";
+
+import { DataTable } from "@/components/admin/DataTable";
+import { AccountForm } from "@/components/admin/AccountForm";
+import {
+  createAccount,
+  deleteAccount,
+  getMe,
+  listAdminAccounts,
+  updateAccount,
+} from "@/lib/admin-api";
+import type { Account, CreateAccount } from "@/types/admin";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
 export default function AdminAccountsPage() {
-  return <h1 className="text-2xl font-bold">Accounts</h1>;
+  const router = useRouter();
+  const [data, setData] = useState<Account[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentUser, setCurrentUser] = useState<Account | null>(null);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingAccount, setEditingAccount] = useState<Account | undefined>(
+    undefined,
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  const fetchAccounts = async () => {
+    setIsLoading(true);
+    try {
+      const response = await listAdminAccounts();
+      setData(Array.isArray(response) ? response : response.items);
+    } catch (error) {
+      console.error("Failed to fetch accounts:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const me = await getMe();
+        if (me.role !== "admin") {
+          router.replace("/admin");
+          return;
+        }
+        setCurrentUser(me);
+        await fetchAccounts();
+      } catch {
+        router.replace("/admin/login");
+      }
+    };
+    init();
+  }, [router]);
+
+  const handleEdit = (account: Account) => {
+    setEditingAccount(account);
+    setIsFormOpen(true);
+  };
+
+  const handleDelete = async (accountId: number) => {
+    if (
+      !window.confirm(
+        "Are you sure you want to delete this account? This action cannot be undone.",
+      )
+    )
+      return;
+    try {
+      await deleteAccount(accountId);
+      await fetchAccounts();
+    } catch (error) {
+      console.error("Failed to delete account:", error);
+      alert("Failed to delete account");
+    }
+  };
+
+  const handleFormSubmit = async (formData: CreateAccount) => {
+    setIsSaving(true);
+    try {
+      if (editingAccount) {
+        await updateAccount(editingAccount.id, formData);
+      } else {
+        await createAccount(formData);
+      }
+      setIsFormOpen(false);
+      setEditingAccount(undefined);
+      fetchAccounts();
+    } catch (error) {
+      console.error("Failed to save account:", error);
+      alert("Failed to save account. The email or PID may already be in use.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const columns: ColumnDef<Account>[] = [
+    {
+      id: "name",
+      header: "Name",
+      cell: ({ row }) =>
+        `${row.original.first_name} ${row.original.last_name}`,
+    },
+    {
+      accessorKey: "email",
+      header: "Email",
+    },
+    {
+      accessorKey: "pid",
+      header: "PID",
+      cell: ({ row }) => (
+        <span className="font-mono text-sm">{row.getValue("pid")}</span>
+      ),
+    },
+    {
+      accessorKey: "role",
+      header: "Role",
+      cell: ({ row }) => {
+        const role = row.getValue("role") as string;
+        return (
+          <span
+            className={`px-2 py-1 rounded-full text-xs font-medium ${role === "admin" ? "bg-purple-100 text-purple-800" : "bg-blue-100 text-blue-800"}`}
+          >
+            {role.charAt(0).toUpperCase() + role.slice(1)}
+          </span>
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: "Actions",
+      cell: ({ row }) => {
+        const account = row.original;
+        const isSelf = currentUser?.id === account.id;
+        return (
+          <div className="flex gap-4">
+            <button
+              onClick={() => handleEdit(account)}
+              className="text-blue-600 hover:text-blue-900 font-medium"
+            >
+              Edit
+            </button>
+            {!isSelf && (
+              <button
+                onClick={() => handleDelete(account.id)}
+                className="text-red-600 hover:text-red-900 font-medium"
+              >
+                Delete
+              </button>
+            )}
+          </div>
+        );
+      },
+    },
+  ];
+
+  if (isFormOpen) {
+    return (
+      <div className="max-w-2xl mx-auto space-y-4">
+        <button
+          onClick={() => {
+            setIsFormOpen(false);
+            setEditingAccount(undefined);
+          }}
+          className="text-blue-600 hover:underline mb-4 inline-block font-medium"
+        >
+          &larr; Back to Accounts Table
+        </button>
+        <AccountForm
+          initialData={editingAccount}
+          onSubmit={handleFormSubmit}
+          onCancel={() => {
+            setIsFormOpen(false);
+            setEditingAccount(undefined);
+          }}
+          isLoading={isSaving}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Accounts Management</h1>
+        <button
+          onClick={() => {
+            setEditingAccount(undefined);
+            setIsFormOpen(true);
+          }}
+          className="bg-blue-600 text-white px-4 py-2 rounded shadow hover:bg-blue-700 transition"
+        >
+          Create Account
+        </button>
+      </div>
+
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+        {isLoading ? (
+          <div className="text-center py-20 text-gray-500">
+            Loading accounts...
+          </div>
+        ) : (
+          <DataTable columns={columns} data={data} />
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/app/admin/districts/page.tsx
+++ b/frontend/src/app/admin/districts/page.tsx
@@ -1,3 +1,183 @@
+"use client";
+
+import { DataTable } from "@/components/admin/DataTable";
+import { DistrictForm } from "@/components/admin/DistrictForm";
+import {
+  createDistrict,
+  deleteDistrict,
+  listAdminDistricts,
+  updateDistrict,
+} from "@/lib/admin-api";
+import type { AdminDistrict, CreateDistrict, UpdateDistrict } from "@/types/admin";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useEffect, useState } from "react";
+
 export default function AdminDistrictsPage() {
-  return <h1 className="text-2xl font-bold">Districts</h1>;
+  const [data, setData] = useState<AdminDistrict[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingDistrict, setEditingDistrict] = useState<
+    AdminDistrict | undefined
+  >(undefined);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const fetchDistricts = async () => {
+    setIsLoading(true);
+    try {
+      const districts = await listAdminDistricts();
+      setData(districts);
+    } catch (error) {
+      console.error("Failed to fetch districts:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchDistricts();
+  }, []);
+
+  const handleEdit = (district: AdminDistrict) => {
+    setEditingDistrict(district);
+    setIsFormOpen(true);
+  };
+
+  const handleDelete = async (districtId: number) => {
+    if (
+      !window.confirm(
+        "Are you sure you want to delete this district? This will fail if senators are still assigned to it.",
+      )
+    )
+      return;
+    try {
+      await deleteDistrict(districtId);
+      await fetchDistricts();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      if (message.includes("409")) {
+        alert(
+          "Cannot delete this district — senators are still assigned to it. Reassign or delete them first.",
+        );
+      } else {
+        alert("Failed to delete district");
+      }
+      console.error("Failed to delete district:", error);
+    }
+  };
+
+  const handleFormSubmit = async (
+    formData: CreateDistrict | UpdateDistrict,
+  ) => {
+    setIsSaving(true);
+    try {
+      if (editingDistrict) {
+        await updateDistrict(editingDistrict.id, formData as UpdateDistrict);
+      } else {
+        await createDistrict(formData as CreateDistrict);
+      }
+      setIsFormOpen(false);
+      setEditingDistrict(undefined);
+      fetchDistricts();
+    } catch (error) {
+      console.error("Failed to save district:", error);
+      alert("Failed to save district");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const columns: ColumnDef<AdminDistrict>[] = [
+    {
+      accessorKey: "district_name",
+      header: "District Name",
+    },
+    {
+      accessorKey: "description",
+      header: "Description",
+      cell: ({ row }) => {
+        const desc = row.getValue("description") as string | null;
+        return desc ? (
+          <span className="text-gray-700">{desc}</span>
+        ) : (
+          <span className="text-gray-400 italic">No description</span>
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: "Actions",
+      cell: ({ row }) => {
+        const district = row.original;
+        return (
+          <div className="flex gap-4">
+            <button
+              onClick={() => handleEdit(district)}
+              className="text-blue-600 hover:text-blue-900 font-medium"
+            >
+              Edit
+            </button>
+            <button
+              onClick={() => handleDelete(district.id)}
+              className="text-red-600 hover:text-red-900 font-medium"
+            >
+              Delete
+            </button>
+          </div>
+        );
+      },
+    },
+  ];
+
+  if (isFormOpen) {
+    return (
+      <div className="max-w-2xl mx-auto space-y-4">
+        <button
+          onClick={() => {
+            setIsFormOpen(false);
+            setEditingDistrict(undefined);
+          }}
+          className="text-blue-600 hover:underline mb-4 inline-block font-medium"
+        >
+          &larr; Back to Districts Table
+        </button>
+        <DistrictForm
+          initialData={editingDistrict}
+          onSubmit={handleFormSubmit}
+          onCancel={() => {
+            setIsFormOpen(false);
+            setEditingDistrict(undefined);
+          }}
+          isLoading={isSaving}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Districts Management</h1>
+        <button
+          onClick={() => {
+            setEditingDistrict(undefined);
+            setIsFormOpen(true);
+          }}
+          className="bg-blue-600 text-white px-4 py-2 rounded shadow hover:bg-blue-700 transition"
+        >
+          Add District
+        </button>
+      </div>
+
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+        {isLoading ? (
+          <div className="text-center py-20 text-gray-500">
+            Loading districts...
+          </div>
+        ) : (
+          <DataTable columns={columns} data={data} />
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/app/admin/staff/page.tsx
+++ b/frontend/src/app/admin/staff/page.tsx
@@ -1,3 +1,192 @@
+"use client";
+
+import { DataTable } from "@/components/admin/DataTable";
+import { StaffForm } from "@/components/admin/StaffForm";
+import {
+  createStaff,
+  deleteStaff,
+  listAdminStaff,
+  updateStaff,
+} from "@/lib/admin-api";
+import type { AdminStaff, CreateStaff, UpdateStaff } from "@/types/admin";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useEffect, useState } from "react";
+
 export default function AdminStaffPage() {
-  return <h1 className="text-2xl font-bold">Staff</h1>;
+  const [data, setData] = useState<AdminStaff[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingStaff, setEditingStaff] = useState<AdminStaff | undefined>(
+    undefined,
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  const fetchStaff = async () => {
+    setIsLoading(true);
+    try {
+      const staff = await listAdminStaff();
+      setData(staff);
+    } catch (error) {
+      console.error("Failed to fetch staff:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStaff();
+  }, []);
+
+  const handleEdit = (staff: AdminStaff) => {
+    setEditingStaff(staff);
+    setIsFormOpen(true);
+  };
+
+  const handleDelete = async (staffId: number) => {
+    if (
+      !window.confirm(
+        "Are you sure you want to delete this staff member? This action cannot be undone.",
+      )
+    )
+      return;
+    try {
+      await deleteStaff(staffId);
+      await fetchStaff();
+    } catch (error) {
+      console.error("Failed to delete staff:", error);
+      alert("Failed to delete staff member");
+    }
+  };
+
+  const handleFormSubmit = async (formData: CreateStaff | UpdateStaff) => {
+    setIsSaving(true);
+    try {
+      if (editingStaff) {
+        await updateStaff(editingStaff.id, formData as UpdateStaff);
+      } else {
+        await createStaff(formData as CreateStaff);
+      }
+      setIsFormOpen(false);
+      setEditingStaff(undefined);
+      fetchStaff();
+    } catch (error) {
+      console.error("Failed to save staff:", error);
+      alert("Failed to save staff member");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const columns: ColumnDef<AdminStaff>[] = [
+    {
+      accessorKey: "display_order",
+      header: "Order",
+      cell: ({ row }) => (
+        <span className="text-gray-500 text-sm">{row.getValue("display_order")}</span>
+      ),
+    },
+    {
+      id: "name",
+      header: "Name",
+      cell: ({ row }) =>
+        `${row.original.first_name} ${row.original.last_name}`,
+    },
+    {
+      accessorKey: "title",
+      header: "Title",
+    },
+    {
+      accessorKey: "email",
+      header: "Email",
+    },
+    {
+      accessorKey: "is_active",
+      header: "Status",
+      cell: ({ row }) => {
+        const isActive = row.getValue("is_active") as boolean;
+        return (
+          <span
+            className={`px-2 py-1 rounded-full text-xs font-medium ${isActive ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-600"}`}
+          >
+            {isActive ? "Active" : "Inactive"}
+          </span>
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: "Actions",
+      cell: ({ row }) => {
+        const staff = row.original;
+        return (
+          <div className="flex gap-4">
+            <button
+              onClick={() => handleEdit(staff)}
+              className="text-blue-600 hover:text-blue-900 font-medium"
+            >
+              Edit
+            </button>
+            <button
+              onClick={() => handleDelete(staff.id)}
+              className="text-red-600 hover:text-red-900 font-medium"
+            >
+              Delete
+            </button>
+          </div>
+        );
+      },
+    },
+  ];
+
+  if (isFormOpen) {
+    return (
+      <div className="max-w-2xl mx-auto space-y-4">
+        <button
+          onClick={() => {
+            setIsFormOpen(false);
+            setEditingStaff(undefined);
+          }}
+          className="text-blue-600 hover:underline mb-4 inline-block font-medium"
+        >
+          &larr; Back to Staff Table
+        </button>
+        <StaffForm
+          initialData={editingStaff}
+          onSubmit={handleFormSubmit}
+          onCancel={() => {
+            setIsFormOpen(false);
+            setEditingStaff(undefined);
+          }}
+          isLoading={isSaving}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Staff Management</h1>
+        <button
+          onClick={() => {
+            setEditingStaff(undefined);
+            setIsFormOpen(true);
+          }}
+          className="bg-blue-600 text-white px-4 py-2 rounded shadow hover:bg-blue-700 transition"
+        >
+          Add Staff Member
+        </button>
+      </div>
+
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+        {isLoading ? (
+          <div className="text-center py-20 text-gray-500">
+            Loading staff...
+          </div>
+        ) : (
+          <DataTable columns={columns} data={data} />
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/app/admin/static-pages/page.tsx
+++ b/frontend/src/app/admin/static-pages/page.tsx
@@ -1,3 +1,136 @@
+"use client";
+
+import { DataTable } from "@/components/admin/DataTable";
+import { StaticPageForm } from "@/components/admin/StaticPageForm";
+import { listStaticPages, updateStaticPage } from "@/lib/admin-api";
+import type { StaticPage } from "@/types";
+import type { UpdateStaticPage } from "@/types/admin";
+import type { ColumnDef } from "@tanstack/react-table";
+import { format } from "date-fns";
+import { useEffect, useState } from "react";
+
 export default function AdminStaticPagesPage() {
-  return <h1 className="text-2xl font-bold">Static Pages</h1>;
+  const [data, setData] = useState<StaticPage[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [editingPage, setEditingPage] = useState<StaticPage | undefined>(
+    undefined,
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  const fetchPages = async () => {
+    setIsLoading(true);
+    try {
+      const pages = await listStaticPages();
+      setData(pages);
+    } catch (error) {
+      console.error("Failed to fetch static pages:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPages();
+  }, []);
+
+  const handleFormSubmit = async (formData: UpdateStaticPage) => {
+    if (!editingPage) return;
+    setIsSaving(true);
+    try {
+      await updateStaticPage(editingPage.page_slug, formData);
+      setEditingPage(undefined);
+      fetchPages();
+    } catch (error) {
+      console.error("Failed to save page:", error);
+      alert("Failed to save page");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const columns: ColumnDef<StaticPage>[] = [
+    {
+      accessorKey: "page_slug",
+      header: "Slug",
+      cell: ({ row }) => (
+        <span className="font-mono text-sm bg-gray-100 px-1.5 py-0.5 rounded">
+          {row.getValue("page_slug")}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "title",
+      header: "Title",
+    },
+    {
+      accessorKey: "updated_at",
+      header: "Last Updated",
+      cell: ({ row }) => {
+        const date = row.getValue("updated_at") as string;
+        try {
+          return format(new Date(date), "MMM d, yyyy h:mm a");
+        } catch {
+          return date;
+        }
+      },
+    },
+    {
+      id: "actions",
+      header: "Actions",
+      cell: ({ row }) => {
+        const page = row.original;
+        return (
+          <button
+            onClick={() => setEditingPage(page)}
+            className="text-blue-600 hover:text-blue-900 font-medium"
+          >
+            Edit
+          </button>
+        );
+      },
+    },
+  ];
+
+  if (editingPage) {
+    return (
+      <div className="max-w-4xl mx-auto space-y-4">
+        <button
+          onClick={() => setEditingPage(undefined)}
+          className="text-blue-600 hover:underline mb-4 inline-block font-medium"
+        >
+          &larr; Back to Pages Table
+        </button>
+        <StaticPageForm
+          initialData={editingPage}
+          onSubmit={handleFormSubmit}
+          onCancel={() => setEditingPage(undefined)}
+          isLoading={isSaving}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold">Static Pages</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            These pages are pre-configured. You can edit their content but not
+            add or remove them.
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+        {isLoading ? (
+          <div className="text-center py-20 text-gray-500">
+            Loading pages...
+          </div>
+        ) : (
+          <DataTable columns={columns} data={data} />
+        )}
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/components/admin/AccountForm.tsx
+++ b/frontend/src/components/admin/AccountForm.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState } from "react";
+import type { Account, CreateAccount } from "@/types/admin";
+
+interface AccountFormProps {
+  initialData?: Account;
+  onSubmit: (data: CreateAccount) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function AccountForm({
+  initialData,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: AccountFormProps) {
+  const [firstName, setFirstName] = useState(initialData?.first_name ?? "");
+  const [lastName, setLastName] = useState(initialData?.last_name ?? "");
+  const [email, setEmail] = useState(initialData?.email ?? "");
+  const [pid, setPid] = useState(initialData?.pid ?? "");
+  const [role, setRole] = useState<"admin" | "staff">(
+    initialData?.role ?? "staff",
+  );
+  const [pidError, setPidError] = useState("");
+
+  const handlePidChange = (value: string) => {
+    setPid(value);
+    if (value && !/^\d{9}$/.test(value)) {
+      setPidError("PID must be exactly 9 digits");
+    } else {
+      setPidError("");
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!/^\d{9}$/.test(pid)) {
+      setPidError("PID must be exactly 9 digits");
+      return;
+    }
+    onSubmit({ first_name: firstName, last_name: lastName, email, pid, role });
+  };
+
+  return (
+    <div className="bg-white p-6 rounded-lg border shadow-sm max-w-2xl w-full">
+      <h2 className="text-2xl font-bold mb-6">
+        {initialData ? "Edit Account" : "Create Account"}
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              First Name
+            </label>
+            <input
+              required
+              type="text"
+              className="w-full p-2 border rounded border-gray-300"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Last Name
+            </label>
+            <input
+              required
+              type="text"
+              className="w-full p-2 border rounded border-gray-300"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Email
+          </label>
+          <input
+            required
+            type="email"
+            className="w-full p-2 border rounded border-gray-300"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            PID
+          </label>
+          <p className="text-xs text-gray-500 mb-1">9-digit UNC PID number.</p>
+          <input
+            required
+            type="text"
+            maxLength={9}
+            className={`w-full p-2 border rounded ${pidError ? "border-red-500" : "border-gray-300"}`}
+            value={pid}
+            onChange={(e) => handlePidChange(e.target.value)}
+            placeholder="123456789"
+          />
+          {pidError && (
+            <p className="text-xs text-red-600 mt-1">{pidError}</p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Role
+          </label>
+          <select
+            className="w-full p-2 border rounded border-gray-300"
+            value={role}
+            onChange={(e) => setRole(e.target.value as "admin" | "staff")}
+          >
+            <option value="staff">Staff</option>
+            <option value="admin">Admin</option>
+          </select>
+          <p className="text-xs text-gray-500 mt-1">
+            Admin accounts can manage all content and other accounts. Staff
+            accounts can manage content but not accounts.
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-3 border-t pt-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            className="px-4 py-2 border rounded text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            {isLoading
+              ? "Saving..."
+              : initialData
+                ? "Update Account"
+                : "Create Account"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/DistrictForm.tsx
+++ b/frontend/src/components/admin/DistrictForm.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import type { AdminDistrict, CreateDistrict, UpdateDistrict } from "@/types/admin";
+
+interface DistrictFormProps {
+  initialData?: AdminDistrict;
+  onSubmit: (data: CreateDistrict | UpdateDistrict) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function DistrictForm({
+  initialData,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: DistrictFormProps) {
+  const [districtName, setDistrictName] = useState(
+    initialData?.district_name ?? "",
+  );
+  const [description, setDescription] = useState(
+    initialData?.description ?? "",
+  );
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({
+      district_name: districtName,
+      description: description || null,
+    });
+  };
+
+  return (
+    <div className="bg-white p-6 rounded-lg border shadow-sm max-w-2xl w-full">
+      <h2 className="text-2xl font-bold mb-6">
+        {initialData ? "Edit District" : "Add District"}
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            District Name
+          </label>
+          <input
+            required
+            type="text"
+            className="w-full p-2 border rounded border-gray-300"
+            value={districtName}
+            onChange={(e) => setDistrictName(e.target.value)}
+            placeholder="e.g. At-Large"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Description (Optional)
+          </label>
+          <textarea
+            className="w-full p-2 border rounded border-gray-300"
+            rows={3}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Brief description of this district..."
+          />
+        </div>
+
+        <div className="flex justify-end gap-3 border-t pt-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            className="px-4 py-2 border rounded text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            {isLoading
+              ? "Saving..."
+              : initialData
+                ? "Update District"
+                : "Add District"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/StaffForm.tsx
+++ b/frontend/src/components/admin/StaffForm.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState } from "react";
+import type { AdminStaff, CreateStaff, UpdateStaff } from "@/types/admin";
+
+interface StaffFormProps {
+  initialData?: AdminStaff;
+  onSubmit: (data: CreateStaff | UpdateStaff) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function StaffForm({
+  initialData,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: StaffFormProps) {
+  const [firstName, setFirstName] = useState(initialData?.first_name ?? "");
+  const [lastName, setLastName] = useState(initialData?.last_name ?? "");
+  const [title, setTitle] = useState(initialData?.title ?? "");
+  const [email, setEmail] = useState(initialData?.email ?? "");
+  const [photoUrl, setPhotoUrl] = useState(initialData?.photo_url ?? "");
+  const [displayOrder, setDisplayOrder] = useState(
+    initialData?.display_order ?? 0,
+  );
+  const [isActive, setIsActive] = useState(initialData?.is_active ?? true);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (initialData) {
+      const data: UpdateStaff = {
+        first_name: firstName,
+        last_name: lastName,
+        title,
+        email,
+        photo_url: photoUrl || null,
+        display_order: displayOrder,
+        is_active: isActive,
+      };
+      onSubmit(data);
+    } else {
+      const data: CreateStaff = {
+        first_name: firstName,
+        last_name: lastName,
+        title,
+        email,
+        display_order: displayOrder,
+      };
+      onSubmit(data);
+    }
+  };
+
+  return (
+    <div className="bg-white p-6 rounded-lg border shadow-sm max-w-2xl w-full">
+      <h2 className="text-2xl font-bold mb-6">
+        {initialData ? "Edit Staff Member" : "Add Staff Member"}
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              First Name
+            </label>
+            <input
+              required
+              type="text"
+              className="w-full p-2 border rounded border-gray-300"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Last Name
+            </label>
+            <input
+              required
+              type="text"
+              className="w-full p-2 border rounded border-gray-300"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Title
+          </label>
+          <input
+            required
+            type="text"
+            className="w-full p-2 border rounded border-gray-300"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. Chief of Staff"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Email
+          </label>
+          <input
+            required
+            type="email"
+            className="w-full p-2 border rounded border-gray-300"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Photo URL (Optional)
+          </label>
+          <input
+            type="url"
+            className="w-full p-2 border rounded border-gray-300"
+            value={photoUrl}
+            onChange={(e) => setPhotoUrl(e.target.value)}
+            placeholder="https://example.com/photo.jpg"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Display Order
+          </label>
+          <p className="text-xs text-gray-500 mb-1">
+            Lower numbers appear first in the staff directory.
+          </p>
+          <input
+            required
+            type="number"
+            className="w-full p-2 border rounded border-gray-300"
+            value={displayOrder}
+            onChange={(e) => setDisplayOrder(Number(e.target.value))}
+          />
+        </div>
+
+        {initialData && (
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="is_active"
+              className="w-4 h-4"
+              checked={isActive}
+              onChange={(e) => setIsActive(e.target.checked)}
+            />
+            <label
+              htmlFor="is_active"
+              className="text-sm font-medium text-gray-700"
+            >
+              Active (uncheck to hide from public directory)
+            </label>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 border-t pt-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            className="px-4 py-2 border rounded text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            {isLoading
+              ? "Saving..."
+              : initialData
+                ? "Update Staff"
+                : "Add Staff"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/StaticPageForm.tsx
+++ b/frontend/src/components/admin/StaticPageForm.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { RichTextEditor } from "./RichTextEditor";
+import type { StaticPage } from "@/types";
+import type { UpdateStaticPage } from "@/types/admin";
+
+interface StaticPageFormProps {
+  initialData: StaticPage;
+  onSubmit: (data: UpdateStaticPage) => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function StaticPageForm({
+  initialData,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: StaticPageFormProps) {
+  const [title, setTitle] = useState(initialData.title);
+  const [body, setBody] = useState(initialData.body);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ title, body });
+  };
+
+  return (
+    <div className="bg-white p-6 rounded-lg border shadow-sm max-w-4xl w-full">
+      <h2 className="text-2xl font-bold mb-1">Edit Page</h2>
+      <p className="text-sm text-gray-500 mb-6">
+        Slug:{" "}
+        <span className="font-mono bg-gray-100 px-1 rounded">
+          {initialData.page_slug}
+        </span>
+      </p>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Page Title
+          </label>
+          <input
+            required
+            type="text"
+            className="w-full p-2 border rounded border-gray-300"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Page Content
+          </label>
+          <RichTextEditor value={body} onChange={setBody} />
+        </div>
+
+        <div className="flex justify-end gap-3 border-t pt-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            className="px-4 py-2 border rounded text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          >
+            {isLoading ? "Saving..." : "Save Changes"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -24,12 +24,14 @@ import type {
   CreateCarouselSlide,
   CreateCommittee,
   CreateDistrict,
+  CreateDistrictMapping,
   CreateFinanceHearingDate,
   CreateLegislation,
   CreateLegislationAction,
   CreateNews,
   CreateSenator,
   CreateStaff,
+  DistrictMapping,
   LoginCredentials,
   LoginResponse,
   UpdateDistrict,
@@ -412,6 +414,32 @@ export async function updateDistrict(
 
 export async function deleteDistrict(id: number): Promise<void> {
   return request<void>(`/admin/districts/${id}`, { method: "DELETE" });
+}
+
+// District Mappings
+export async function listDistrictMappings(
+  districtId: number,
+): Promise<DistrictMapping[]> {
+  return request(`/admin/districts/${districtId}/mappings`, { method: "GET" });
+}
+
+export async function createDistrictMapping(
+  districtId: number,
+  data: CreateDistrictMapping,
+): Promise<DistrictMapping> {
+  return request(`/admin/districts/${districtId}/mappings`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteDistrictMapping(
+  districtId: number,
+  mapId: number,
+): Promise<void> {
+  return request<void>(`/admin/districts/${districtId}/mappings/${mapId}`, {
+    method: "DELETE",
+  });
 }
 
 // Static pages

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -14,13 +14,16 @@ import type {
 } from "@/types";
 import type {
   Account,
+  AdminDistrict,
   AdminNews,
+  AdminStaff,
   AssignCommitteeMember,
   CreateAccount,
   CreateBudgetData,
   CreateCalendarEvent,
   CreateCarouselSlide,
   CreateCommittee,
+  CreateDistrict,
   CreateFinanceHearingDate,
   CreateLegislation,
   CreateLegislationAction,
@@ -29,10 +32,12 @@ import type {
   CreateStaff,
   LoginCredentials,
   LoginResponse,
+  UpdateDistrict,
   UpdateFinanceHearingConfig,
   UpdateFinanceHearingDate,
   UpdateNews,
   UpdateSenator,
+  UpdateStaff,
   UpdateStaticPage,
 } from "@/types/admin";
 import type { PaginatedResponse } from "@/types/api";
@@ -332,6 +337,10 @@ export async function removeCommitteeMember(
 }
 
 // Staff
+export async function listAdminStaff(): Promise<AdminStaff[]> {
+  return request("/admin/staff", { method: "GET" });
+}
+
 export async function createStaff(data: CreateStaff): Promise<Staff> {
   return request("/admin/staff", {
     method: "POST",
@@ -341,7 +350,7 @@ export async function createStaff(data: CreateStaff): Promise<Staff> {
 
 export async function updateStaff(
   id: number,
-  data: CreateStaff,
+  data: UpdateStaff,
 ): Promise<Staff> {
   return request(`/admin/staff/${id}`, {
     method: "PUT",
@@ -377,7 +386,39 @@ export async function deleteBudgetData(id: number): Promise<void> {
   return request<void>(`/admin/budget/${id}`, { method: "DELETE" });
 }
 
+// Districts
+export async function listAdminDistricts(): Promise<AdminDistrict[]> {
+  return request("/admin/districts", { method: "GET" });
+}
+
+export async function createDistrict(
+  data: CreateDistrict,
+): Promise<AdminDistrict> {
+  return request("/admin/districts", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateDistrict(
+  id: number,
+  data: UpdateDistrict,
+): Promise<AdminDistrict> {
+  return request(`/admin/districts/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteDistrict(id: number): Promise<void> {
+  return request<void>(`/admin/districts/${id}`, { method: "DELETE" });
+}
+
 // Static pages
+export async function listStaticPages(): Promise<StaticPage[]> {
+  return request("/admin/pages", { method: "GET" });
+}
+
 export async function updateStaticPage(
   slug: string,
   data: UpdateStaticPage,
@@ -389,6 +430,15 @@ export async function updateStaticPage(
 }
 
 // Accounts
+export async function listAdminAccounts(
+  page: number = 1,
+  limit: number = 100,
+): Promise<PaginatedResponse<Account>> {
+  return request(`/admin/accounts?page=${page}&limit=${limit}`, {
+    method: "GET",
+  });
+}
+
 export async function createAccount(data: CreateAccount): Promise<Account> {
   return request("/admin/accounts", {
     method: "POST",

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -131,12 +131,49 @@ export interface AssignCommitteeMember {
   role: string;
 }
 
+export interface AdminStaff {
+  id: number;
+  first_name: string;
+  last_name: string;
+  title: string;
+  email: string;
+  photo_url: string | null;
+  display_order: number;
+  is_active: boolean;
+}
+
 export interface CreateStaff {
   first_name: string;
   last_name: string;
   title: string;
   email: string;
   display_order: number;
+}
+
+export interface UpdateStaff {
+  first_name: string;
+  last_name: string;
+  title: string;
+  email: string;
+  photo_url: string | null;
+  display_order: number;
+  is_active: boolean;
+}
+
+export interface AdminDistrict {
+  id: number;
+  district_name: string;
+  description: string | null;
+}
+
+export interface CreateDistrict {
+  district_name: string;
+  description: string | null;
+}
+
+export interface UpdateDistrict {
+  district_name: string | null;
+  description: string | null;
 }
 
 export interface CreateBudgetData {

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -177,6 +177,16 @@ export interface UpdateDistrict {
   description: string | null;
 }
 
+export interface DistrictMapping {
+  id: number;
+  district_id: number;
+  mapping_value: string;
+}
+
+export interface CreateDistrictMapping {
+  mapping_value: string;
+}
+
 export interface CreateBudgetData {
   fiscal_year: string;
   category: string;


### PR DESCRIPTION
Implements the four remaining simple CRUD admin pages to complete the admin dashboard surface area.
Changes:

Added GET /api/admin/staff endpoint and AdminStaffDTO schema since the admin page needs display_order and is_active fields that the existing public StaffDTO doesn't expose
Built StaffForm, AccountForm, DistrictForm, and StaticPageForm components following the existing NewsForm pattern
Replaced stub pages with full implementations for staff (CRUD), accounts (CRUD, admin-only, self-delete protected), districts (CRUD, friendly error when delete blocked by linked senators), and static pages (edit-only with TipTap rich text editor)
Added list and CRUD functions for all four entities to admin-api.ts
Added AdminStaff, UpdateStaff, AdminDistrict, CreateDistrict, UpdateDistrict types to types/admin.ts

Closes #98