### PR TITLE
Homepage — Finance Hearing Button + Finance Hearing Page

### DIFF
--- a/frontend/src/app/funding/apply/page.tsx
+++ b/frontend/src/app/funding/apply/page.tsx
@@ -1,5 +1,109 @@
 import StaticPage from "@/components/StaticPage";
+import { getFinanceHearings } from "@/lib/api";
 
-export default function FundingApplyPage() {
-  return <StaticPage slug="how-to-apply" />;
+function formatHearingDate(dateString: string): string {
+  const parsed = new Date(`${dateString}T12:00:00`);
+  if (Number.isNaN(parsed.getTime())) return dateString;
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(parsed);
+}
+
+function formatHearingTime(timeString: string): string {
+  const [hoursRaw, minutesRaw] = timeString.split(":");
+  const hours = Number(hoursRaw);
+  const minutes = Number(minutesRaw);
+
+  if (
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return timeString;
+  }
+
+  const period = hours >= 12 ? "PM" : "AM";
+  const twelveHour = hours % 12 || 12;
+  return `${twelveHour}:${minutes.toString().padStart(2, "0")} ${period}`;
+}
+
+export default async function FundingApplyPage() {
+  const hearingConfig = await getFinanceHearings().catch(() => null);
+  const hearingDates = [...(hearingConfig?.dates ?? [])].sort((a, b) => {
+    const left = `${a.hearing_date} ${a.hearing_time}`;
+    const right = `${b.hearing_date} ${b.hearing_time}`;
+    return left.localeCompare(right);
+  });
+
+  return (
+    <div className="space-y-10 pb-12">
+      <StaticPage slug="how-to-apply" />
+
+      <section
+        id="finance-hearing-dates"
+        className="container mx-auto px-4"
+        aria-label="Finance hearing dates"
+      >
+        <div className="rounded-lg border border-slate-200 bg-white p-6">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h2 className="text-2xl font-semibold text-slate-900">
+              Finance Hearing Dates
+            </h2>
+            {hearingConfig?.is_active ? (
+              <span className="inline-flex items-center rounded-md border border-emerald-300 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+                Hearing Season Active
+              </span>
+            ) : (
+              <span className="inline-flex items-center rounded-md border border-slate-300 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600">
+                Currently Inactive
+              </span>
+            )}
+          </div>
+
+          {hearingDates.length === 0 ? (
+            <p className="mt-4 text-slate-600">
+              No finance hearing dates are available right now.
+            </p>
+          ) : (
+            <ul className="mt-5 space-y-3">
+              {hearingDates.map((item) => (
+                <li
+                  key={item.id}
+                  className="rounded-md border border-slate-200 bg-white p-4"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-base font-medium text-slate-900">
+                        {formatHearingDate(item.hearing_date)} at{" "}
+                        {formatHearingTime(item.hearing_time)}
+                      </p>
+                      <p className="mt-1 text-sm text-slate-700">
+                        {item.location || "Location TBD"}
+                      </p>
+                      {item.description ? (
+                        <p className="mt-1 text-sm text-slate-600">
+                          {item.description}
+                        </p>
+                      ) : null}
+                    </div>
+                    {item.is_full ? (
+                      <span className="inline-flex items-center rounded-md border border-amber-300 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
+                        Full
+                      </span>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,18 +1,25 @@
 import CalendarWidget from "@/components/calendar/CalendarWidget";
 import Carousel from "@/components/home/Carousel";
+import FinanceHearingButton from "@/components/home/FinanceHearingButton";
 import RecentNews from "@/components/home/RecentNews";
-import { getCarousel, getEvents } from "@/lib/api";
+import { getCarousel, getEvents, getFinanceHearings } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
   const slides = await getCarousel().catch(() => []);
   const events = await getEvents().catch(() => []);
+  const financeHearings = await getFinanceHearings().catch(() => null);
 
   return (
     <div className="min-h-screen bg-gray-50">
       <Carousel slides={slides} />
       <div className="container mx-auto px-4 py-12">
+        {financeHearings?.is_active ? (
+          <div className="mb-10">
+            <FinanceHearingButton />
+          </div>
+        ) : null}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-12">
           <div className="lg:col-span-2">
             <RecentNews />

--- a/frontend/src/components/home/FinanceHearingButton.tsx
+++ b/frontend/src/components/home/FinanceHearingButton.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+type FinanceHearingButtonProps = {
+  href?: string;
+};
+
+export default function FinanceHearingButton({
+  href = "/funding/apply#finance-hearing-dates",
+}: FinanceHearingButtonProps) {
+  return (
+    <Link
+      href={href}
+      className="block rounded-lg border border-slate-300 bg-white p-5 transition hover:bg-slate-50"
+      aria-label="View available finance hearing dates"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-medium text-slate-700">Funding Season</p>
+          <h2 className="text-xl font-semibold text-slate-900">
+            Schedule Your Finance Hearing
+          </h2>
+          <p className="mt-1 text-sm text-slate-600">
+            See open hearing dates and reserve a spot before they fill.
+          </p>
+        </div>
+        <span className="inline-flex items-center justify-center rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-800">
+          View Dates
+        </span>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
The finance hearing scheduling button is conditionally visible on the homepage during hearing season. When active, it links to a page showing available hearing dates.

Changes:

- FinanceHearingButton component
- Added to homepage
- Wired funding apply page to fetch and display hearing dates

Closes #101 