### PR TITLE
Added bleach dependency to pyproject.toml

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "sqlalchemy==2.0.38",
   "pyodbc==5.3.0",
   "python-jose[cryptography]==3.3.0",
+  "bleach==6.1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
There was a "dependency conflict" with requirements.txt and pyproject.toml, where post_create.sh would always use pyproject.toml, which lacked the neccessary bleach import for backend/utils/sanitization.py

Changes:
- added "bleach==6.1.0" to dependencies in pyproject.toml

Author Notes: 
I am unsure of the use of having both pyproject.toml and requirements.txt. If keeping both, we have to update both locations with same information when doing new installs.


