### PR TITLE
Image Upload Endpoint + Storage

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -10,3 +10,7 @@ if not JWT_SECRET:
 
 JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
 ACCESS_TOKEN_EXPIRE_HOURS = int(os.getenv("ACCESS_TOKEN_EXPIRE_HOURS", "24"))
+
+UPLOAD_DIR = os.getenv("UPLOAD_DIR", "/app/uploads")
+UPLOAD_BASE_URL = os.getenv("UPLOAD_BASE_URL", "/api/uploads")
+MAX_UPLOAD_SIZE_BYTES = int(os.getenv("MAX_UPLOAD_SIZE_BYTES", str(5 * 1024 * 1024)))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,6 +19,7 @@ from app.routers import (
     pages,
     senators,
     staff,
+    uploads,
 )
 from app.routers.admin import accounts as admin_accounts
 from app.routers.admin import budget as admin_budget
@@ -34,6 +35,7 @@ from app.routers.admin import news as admin_news
 from app.routers.admin import pages as admin_pages
 from app.routers.admin import senators as admin_senators
 from app.routers.admin import staff as admin_staff
+from app.routers.admin import upload as admin_upload
 
 load_dotenv()
 
@@ -67,6 +69,7 @@ app.include_router(budget.router)
 app.include_router(pages.router)
 app.include_router(events.router)
 app.include_router(legislation.router)
+app.include_router(uploads.router)
 app.include_router(admin_news.router)
 
 # Include Admin routers
@@ -83,6 +86,7 @@ app.include_router(admin_pages.router)
 app.include_router(admin_districts.router)
 app.include_router(admin_district_mapping.router)
 app.include_router(admin_accounts.router)
+app.include_router(admin_upload.router)
 
 
 @app.get("/")

--- a/backend/app/routers/admin/upload.py
+++ b/backend/app/routers/admin/upload.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
-from PIL import Image, UnidentifiedImageError
+from PIL import Image, ImageOps, UnidentifiedImageError
 
 from app.config import MAX_UPLOAD_SIZE_BYTES, UPLOAD_BASE_URL, UPLOAD_DIR
 from app.dependencies.auth import get_current_user
@@ -56,11 +56,13 @@ def _save_resized_images(image: Image.Image, extension: str) -> str:
     working = image.convert("RGB") if extension == "jpg" else image.copy()
 
     standard = working.copy()
-    standard.thumbnail((800, 800))
+    if standard.width > 800:
+        ratio = 800 / standard.width
+        resized_height = round(standard.height * ratio)
+        standard = standard.resize((800, resized_height), Image.Resampling.LANCZOS)
     standard.save(uploads_dir / main_filename, **save_kwargs)
 
-    thumb = working.copy()
-    thumb.thumbnail((150, 150))
+    thumb = ImageOps.fit(working.copy(), (150, 150), method=Image.Resampling.LANCZOS)
     thumb.save(uploads_dir / thumb_filename, **save_kwargs)
 
     return main_filename

--- a/backend/app/routers/admin/upload.py
+++ b/backend/app/routers/admin/upload.py
@@ -1,0 +1,79 @@
+"""Admin upload endpoints for image assets."""
+
+from io import BytesIO
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from PIL import Image, UnidentifiedImageError
+
+from app.config import MAX_UPLOAD_SIZE_BYTES, UPLOAD_BASE_URL, UPLOAD_DIR
+from app.dependencies.auth import get_current_user
+from app.models import Admin
+
+router = APIRouter(prefix="/api/admin", tags=["admin-upload"])
+
+_ALLOWED_FORMATS = {
+    "JPEG": "jpg",
+    "PNG": "png",
+    "WEBP": "webp",
+}
+
+
+def _validate_and_load_image(content: bytes) -> tuple[Image.Image, str]:
+    """Validate uploaded bytes as a supported image and return image + extension."""
+    if len(content) > MAX_UPLOAD_SIZE_BYTES:
+        raise HTTPException(status_code=413, detail="File too large. Max size is 5MB")
+
+    try:
+        image = Image.open(BytesIO(content))
+        image.load()
+    except (UnidentifiedImageError, OSError) as exc:
+        raise HTTPException(status_code=400, detail="Unsupported file type") from exc
+
+    fmt = (image.format or "").upper()
+    if fmt not in _ALLOWED_FORMATS:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+
+    return image, _ALLOWED_FORMATS[fmt]
+
+
+def _save_resized_images(image: Image.Image, extension: str) -> str:
+    """Save standard and thumbnail variants and return the main filename."""
+    uploads_dir = Path(UPLOAD_DIR)
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+
+    base_name = uuid4().hex
+    main_filename = f"{base_name}.{extension}"
+    thumb_filename = f"{base_name}_thumb.{extension}"
+
+    save_kwargs: dict[str, int | bool] = {}
+    if extension in {"jpg", "webp"}:
+        save_kwargs["quality"] = 90
+    if extension == "jpg":
+        save_kwargs["optimize"] = True
+
+    working = image.convert("RGB") if extension == "jpg" else image.copy()
+
+    standard = working.copy()
+    standard.thumbnail((800, 800))
+    standard.save(uploads_dir / main_filename, **save_kwargs)
+
+    thumb = working.copy()
+    thumb.thumbnail((150, 150))
+    thumb.save(uploads_dir / thumb_filename, **save_kwargs)
+
+    return main_filename
+
+
+@router.post("/upload")
+async def upload_image(
+    file: UploadFile = File(...),
+    current_user: Admin = Depends(get_current_user),
+):
+    """Upload an image and return a relative URL to the resized standard image."""
+    _ = current_user
+    content = await file.read()
+    image, extension = _validate_and_load_image(content)
+    filename = _save_resized_images(image, extension)
+    return {"url": f"{UPLOAD_BASE_URL}/{filename}"}

--- a/backend/app/routers/uploads.py
+++ b/backend/app/routers/uploads.py
@@ -1,0 +1,28 @@
+"""Public file-serving endpoints for uploaded images."""
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse
+
+from app.config import UPLOAD_DIR
+
+router = APIRouter(prefix="/api/uploads", tags=["uploads"])
+
+
+@router.get("/{filename}")
+def get_uploaded_file(filename: str):
+    """Serve files from the configured upload directory."""
+    if Path(filename).name != filename:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    filepath = (Path(UPLOAD_DIR) / filename).resolve()
+    uploads_root = Path(UPLOAD_DIR).resolve()
+
+    if uploads_root not in filepath.parents and filepath != uploads_root:
+        raise HTTPException(status_code=404, detail="File not found")
+
+    if not filepath.exists() or not filepath.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    return FileResponse(filepath)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
   "pyodbc==5.3.0",
   "python-jose[cryptography]==3.3.0",
   "bleach==6.1.0",
+  "python-multipart==0.0.20",
+  "Pillow==11.2.1",
 ]
 
 [project.optional-dependencies]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,7 @@ bleach==6.1.0
 
 # JSON Web Token
 python-jose[cryptography]==3.3.0
+
+# Uploads & image processing
+python-multipart==0.0.20
+Pillow==11.2.1

--- a/backend/tests/routers/test_admin_upload.py
+++ b/backend/tests/routers/test_admin_upload.py
@@ -47,8 +47,15 @@ def test_valid_upload(admin_client, tmp_path, monkeypatch):
     assert body["url"].startswith("/api/uploads/")
 
     filename = body["url"].split("/")[-1]
+    thumb_filename = f"{filename.rsplit('.', 1)[0]}_thumb.{filename.rsplit('.', 1)[1]}"
     assert (tmp_path / filename).exists()
-    assert (tmp_path / f"{filename.rsplit('.', 1)[0]}_thumb.{filename.rsplit('.', 1)[1]}").exists()
+    assert (tmp_path / thumb_filename).exists()
+
+    with Image.open(tmp_path / filename) as uploaded:
+        assert uploaded.size == (800, 480)
+
+    with Image.open(tmp_path / thumb_filename) as thumb:
+        assert thumb.size == (150, 150)
 
     get_response = admin_client.get(body["url"])
     assert get_response.status_code == 200
@@ -81,3 +88,22 @@ def test_oversized_file(admin_client, tmp_path, monkeypatch):
 
     assert response.status_code == 413
     assert response.json()["detail"] == "File too large. Max size is 5MB"
+
+
+def test_standard_resize_only_limits_width(admin_client, tmp_path, monkeypatch):
+    from app.routers.admin import upload as upload_router
+
+    monkeypatch.setattr(upload_router, "UPLOAD_DIR", str(tmp_path))
+
+    # Width is already under 800, so the standard image should keep original dimensions.
+    payload = _make_png_bytes(width=600, height=2000)
+    response = admin_client.post(
+        "/api/admin/upload",
+        files={"file": ("portrait.png", payload, "image/png")},
+    )
+
+    assert response.status_code == 200
+    filename = response.json()["url"].split("/")[-1]
+
+    with Image.open(tmp_path / filename) as uploaded:
+        assert uploaded.size == (600, 2000)

--- a/backend/tests/routers/test_admin_upload.py
+++ b/backend/tests/routers/test_admin_upload.py
@@ -1,0 +1,83 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin
+
+
+@pytest.fixture
+def admin_client(client, test_db, seeded_admins):
+    admin = seeded_admins["admin"]
+
+    def _override_current_user():
+        return test_db.query(Admin).filter(Admin.id == admin.id).first()
+
+    app.dependency_overrides[get_current_user] = _override_current_user
+    yield client
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _make_png_bytes(width: int = 1000, height: int = 600) -> bytes:
+    image = Image.new("RGB", (width, height), color="red")
+    buf = BytesIO()
+    image.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_valid_upload(admin_client, tmp_path, monkeypatch):
+    from app.routers import uploads as uploads_router
+    from app.routers.admin import upload as upload_router
+
+    monkeypatch.setattr(upload_router, "UPLOAD_DIR", str(tmp_path))
+    monkeypatch.setattr(upload_router, "UPLOAD_BASE_URL", "/api/uploads")
+    monkeypatch.setattr(uploads_router, "UPLOAD_DIR", str(tmp_path))
+
+    payload = _make_png_bytes()
+    response = admin_client.post(
+        "/api/admin/upload",
+        files={"file": ("headshot.png", payload, "image/png")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "url" in body
+    assert body["url"].startswith("/api/uploads/")
+
+    filename = body["url"].split("/")[-1]
+    assert (tmp_path / filename).exists()
+    assert (tmp_path / f"{filename.rsplit('.', 1)[0]}_thumb.{filename.rsplit('.', 1)[1]}").exists()
+
+    get_response = admin_client.get(body["url"])
+    assert get_response.status_code == 200
+
+
+def test_invalid_file_type(admin_client, tmp_path, monkeypatch):
+    from app.routers.admin import upload as upload_router
+
+    monkeypatch.setattr(upload_router, "UPLOAD_DIR", str(tmp_path))
+
+    response = admin_client.post(
+        "/api/admin/upload",
+        files={"file": ("notes.txt", b"this-is-not-an-image", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported file type"
+
+
+def test_oversized_file(admin_client, tmp_path, monkeypatch):
+    from app.routers.admin import upload as upload_router
+
+    monkeypatch.setattr(upload_router, "UPLOAD_DIR", str(tmp_path))
+
+    oversized = b"x" * (5 * 1024 * 1024 + 1)
+    response = admin_client.post(
+        "/api/admin/upload",
+        files={"file": ("big.png", oversized, "image/png")},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["detail"] == "File too large. Max size is 5MB"


### PR DESCRIPTION
Multiple admin features need image upload: news articles, senator headshots, carousel slides, and staff photos. A centralized upload endpoint keeps the pattern consistent.

Changes:

- Added authenticated image upload endpoint at `upload.py` with type/size validation, UUID filenames, and Pillow resizing (standard + thumbnail).
- Added public file-serving endpoint at `uploads.py` for GET /api/uploads/:filename.
- Wired both routers into app startup in `main.py`.
- Added upload config/env knobs in `config.py`.
- Added required dependencies in `requirements.txt` and `pyproject.toml`.
- Added tests for valid upload, invalid file type, and oversized file in `test_admin_upload.py`; fixed Ruff import-order lint there.

Closes #113 
