### PR TITLE
Image Upload Integration in Admin Forms

### DIFF
--- a/backend/app/schemas/senator.py
+++ b/backend/app/schemas/senator.py
@@ -31,6 +31,7 @@ class CreateSenatorDTO(BaseModel):
     email: EmailStr
     district_id: int
     session_number: int
+    headshot_url: str | None = None
 
 
 class UpdateSenatorDTO(BaseModel):
@@ -40,3 +41,4 @@ class UpdateSenatorDTO(BaseModel):
     district_id: int | None = None
     is_active: bool | None = None
     session_number: int | None = None
+    headshot_url: str | None = None

--- a/backend/app/schemas/staff.py
+++ b/backend/app/schemas/staff.py
@@ -32,6 +32,7 @@ class CreateStaffDTO(BaseModel):
     last_name: str
     title: str
     email: EmailStr
+    photo_url: str | None = None
     display_order: int
 
 

--- a/backend/tests/routes/test_admin_staff.py
+++ b/backend/tests/routes/test_admin_staff.py
@@ -110,6 +110,17 @@ class TestCreateAdminStaff:
         for key in ("id", "first_name", "last_name", "title", "email"):
             assert key in resp
 
+    def test_photo_url_can_be_set_on_create(self, write_admin_client):
+        payload = {**_CREATE_PAYLOAD, "photo_url": "/api/uploads/staff-photo.jpg"}
+        resp = write_admin_client.post("/api/admin/staff", json=payload)
+        assert resp.status_code == 201
+        assert resp.json()["photo_url"] == "/api/uploads/staff-photo.jpg"
+
+    def test_photo_url_defaults_to_none_on_create(self, write_admin_client):
+        resp = write_admin_client.post("/api/admin/staff", json=_CREATE_PAYLOAD)
+        assert resp.status_code == 201
+        assert resp.json()["photo_url"] is None
+
     def test_missing_required_field_returns_422(self, write_admin_client):
         bad = {k: v for k, v in _CREATE_PAYLOAD.items() if k != "email"}
         assert write_admin_client.post("/api/admin/staff", json=bad).status_code == 422

--- a/frontend/src/components/admin/CarouselSlideForm.tsx
+++ b/frontend/src/components/admin/CarouselSlideForm.tsx
@@ -3,6 +3,7 @@
 import type { CarouselSlide } from "@/types";
 import type { CreateCarouselSlide } from "@/types/admin";
 import { useState } from "react";
+import { ImageUpload } from "./ImageUpload";
 
 interface CarouselSlideFormProps {
   initialData?: CarouselSlide;
@@ -53,34 +54,18 @@ export function CarouselSlideForm({
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="space-y-2 md:col-span-2">
-            <label className="block text-sm font-medium text-gray-700">
-              Image URL *
-            </label>
-            <input
-              type="text"
-              name="image_url"
-              required
+            <ImageUpload
+              label="Slide Image"
               value={formData.image_url}
-              onChange={handleChange}
-              className="w-full border border-gray-300 rounded-md py-2 px-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="https://example.com/image.jpg"
+              onChange={(url) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  image_url: url,
+                }))
+              }
+              required
+              disabled={isLoading}
             />
-            {formData.image_url && (
-              <div className="mt-2 text-sm text-gray-500">
-                <p className="mb-2">Preview:</p>
-                <div className="relative h-48 w-full rounded bg-gray-100 border overflow-hidden">
-                  <img
-                    src={formData.image_url}
-                    alt="Preview"
-                    className="w-full h-full object-cover"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).src =
-                        "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25'%3E%3Crect width='100%25' height='100%25' fill='%23f3f4f6'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='14px' fill='%239ca3af'%3EInvalid Image URL%3C/text%3E%3C/svg%3E";
-                    }}
-                  />
-                </div>
-              </div>
-            )}
           </div>
 
           <div className="space-y-2 md:col-span-2">
@@ -141,7 +126,11 @@ export function CarouselSlideForm({
             disabled={isLoading}
             className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
           >
-            {isLoading ? "Saving..." : initialData ? "Update Slide" : "Create Slide"}
+            {isLoading
+              ? "Saving..."
+              : initialData
+                ? "Update Slide"
+                : "Create Slide"}
           </button>
         </div>
       </form>

--- a/frontend/src/components/admin/ImageUpload.tsx
+++ b/frontend/src/components/admin/ImageUpload.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { uploadAdminImage } from "@/lib/admin-api";
+import { useEffect, useId, useRef, useState } from "react";
+
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+const ACCEPTED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+
+interface ImageUploadProps {
+  label: string;
+  value: string;
+  onChange: (url: string) => void;
+  required?: boolean;
+  disabled?: boolean;
+}
+
+function resolveImageSrc(url: string): string {
+  if (!url) return "";
+  if (/^https?:\/\//i.test(url) || url.startsWith("data:")) return url;
+  if (!url.startsWith("/")) return url;
+
+  const apiBase = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiBase) return url;
+
+  try {
+    const origin = new URL(apiBase).origin;
+    return `${origin}${url}`;
+  } catch {
+    return url;
+  }
+}
+
+function toFriendlyError(message: string): string {
+  const normalized = message.toLowerCase();
+  if (normalized.includes("too large") || normalized.includes("413")) {
+    return "File too large. Max 5MB, JPEG/PNG/WebP.";
+  }
+  if (normalized.includes("unsupported") || normalized.includes("file type")) {
+    return "Unsupported file type. Please upload JPEG, PNG, or WebP.";
+  }
+  return message;
+}
+
+export function ImageUpload({
+  label,
+  value,
+  onChange,
+  required = false,
+  disabled = false,
+}: ImageUploadProps) {
+  const inputId = useId();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [localPreviewUrl, setLocalPreviewUrl] = useState<string | null>(null);
+
+  const resolvedValue = resolveImageSrc(value);
+  const previewUrl = localPreviewUrl ?? resolvedValue;
+
+  useEffect(() => {
+    return () => {
+      if (localPreviewUrl) {
+        URL.revokeObjectURL(localPreviewUrl);
+      }
+    };
+  }, [localPreviewUrl]);
+
+  const uploadFile = async (file: File) => {
+    if (!ACCEPTED_MIME_TYPES.has(file.type)) {
+      setError("Unsupported file type. Please upload JPEG, PNG, or WebP.");
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setError("File too large. Max 5MB, JPEG/PNG/WebP.");
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(file);
+    if (localPreviewUrl) {
+      URL.revokeObjectURL(localPreviewUrl);
+    }
+    setLocalPreviewUrl(objectUrl);
+    setError(null);
+    setIsUploading(true);
+    setUploadProgress(0);
+
+    try {
+      const response = await uploadAdminImage(file, (percent) => {
+        setUploadProgress(percent);
+      });
+      onChange(response.url);
+    } catch (uploadError) {
+      const message =
+        uploadError instanceof Error ? uploadError.message : "Upload failed.";
+      setError(toFriendlyError(message));
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const onFileInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    void uploadFile(file);
+    event.target.value = "";
+  };
+
+  const onDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+    if (disabled || isUploading) return;
+    const file = event.dataTransfer.files?.[0];
+    if (!file) return;
+    void uploadFile(file);
+  };
+
+  return (
+    <div>
+      <label
+        htmlFor={inputId}
+        className="block text-sm font-medium text-gray-700 mb-1"
+      >
+        {label} {required ? <span className="text-red-500">*</span> : null}
+      </label>
+
+      <div
+        onDragOver={(event) => {
+          event.preventDefault();
+          if (!disabled && !isUploading) setIsDragging(true);
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={onDrop}
+        className={`rounded-lg border-2 border-dashed p-4 transition-colors ${
+          isDragging
+            ? "border-blue-500 bg-blue-50"
+            : "border-gray-300 bg-gray-50"
+        } ${disabled ? "opacity-60" : ""}`}
+      >
+        <input
+          id={inputId}
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          onChange={onFileInputChange}
+          className="hidden"
+          disabled={disabled || isUploading}
+        />
+
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-gray-600">
+            Drag and drop an image here, or use the picker.
+          </p>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled || isUploading}
+            className="w-fit px-3 py-1.5 text-sm bg-white border border-gray-300 rounded hover:bg-gray-100 disabled:opacity-60"
+          >
+            {isUploading ? "Uploading..." : "Choose Image"}
+          </button>
+          <p className="text-xs text-gray-500">Max 5MB, JPEG/PNG/WebP</p>
+
+          {isUploading ? (
+            <div className="space-y-1">
+              <div className="h-2 w-full bg-gray-200 rounded overflow-hidden">
+                <div
+                  className="h-full bg-blue-600 transition-all"
+                  style={{ width: `${uploadProgress}%` }}
+                />
+              </div>
+              <p className="text-xs text-gray-600">
+                Uploading {uploadProgress}%
+              </p>
+            </div>
+          ) : null}
+
+          {error ? <p className="text-sm text-red-600">{error}</p> : null}
+        </div>
+      </div>
+
+      {previewUrl ? (
+        <div className="mt-3">
+          <p className="text-sm text-gray-600 mb-2">Preview</p>
+          <div className="relative h-48 w-full rounded border bg-gray-100 overflow-hidden">
+            <img
+              src={previewUrl}
+              alt="Uploaded preview"
+              className="w-full h-full object-cover"
+            />
+          </div>
+          {value ? (
+            <p className="mt-2 text-xs text-gray-500 break-all">
+              Stored URL: {value}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/LeadershipForm.tsx
+++ b/frontend/src/components/admin/LeadershipForm.tsx
@@ -8,6 +8,7 @@ import {
   UpdateLeadership,
 } from "@/types/admin";
 import { useEffect, useState } from "react";
+import { ImageUpload } from "./ImageUpload";
 
 interface LeadershipFormProps {
   initialData?: AdminLeadership;
@@ -177,19 +178,12 @@ export function LeadershipForm({
           />
         </div>
 
-        {/* Headshot URL Field */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Photo URL (Optional)
-          </label>
-          <input
-            type="url"
-            className="w-full p-2 border rounded border-gray-300"
-            value={headShotUrl}
-            onChange={(e) => setHeadShotUrl(e.target.value)}
-            placeholder="https://example.com/photo.jpg"
-          />
-        </div>
+        <ImageUpload
+          label="Photo (Optional)"
+          value={headShotUrl}
+          onChange={setHeadShotUrl}
+          disabled={isLoading}
+        />
 
         {/* Active Status Checkbox */}
         <div className="flex items-center">

--- a/frontend/src/components/admin/NewsForm.tsx
+++ b/frontend/src/components/admin/NewsForm.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { AdminNews, CreateNews, UpdateNews } from "@/types/admin";
 import { useState } from "react";
+import { ImageUpload } from "./ImageUpload";
 import { RichTextEditor } from "./RichTextEditor";
-import { CreateNews, UpdateNews } from "@/types/admin";
-import { AdminNews } from "@/types/admin";
 
 interface NewsFormProps {
   // If we pass an existing article in, the form starts in "Edit Mode"
@@ -22,17 +22,17 @@ export function NewsForm({
   onCancel,
   isLoading = false,
 }: NewsFormProps) {
-  // We create state for every field on the form. 
+  // We create state for every field on the form.
   // If initialData exists, we load it. Otherwise, we start blank.
   const [title, setTitle] = useState(initialData?.title || "");
   const [summary, setSummary] = useState(initialData?.summary || "");
   const [body, setBody] = useState(initialData?.body || "");
   const [imageUrl, setImageUrl] = useState(initialData?.image_url || "");
-  
-  // Note: Your initialData might have 'status' string instead of 'is_published' boolean, 
+
+  // Note: Your initialData might have 'status' string instead of 'is_published' boolean,
   // so we check if it's currently published, otherwise start as false.
   const [isPublished, setIsPublished] = useState(
-    initialData?.is_published ?? false
+    initialData?.is_published ?? false,
   );
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -92,19 +92,12 @@ export function NewsForm({
           />
         </div>
 
-        {/* Image URL Field */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Cover Image URL (Optional)
-          </label>
-          <input
-            type="url"
-            className="w-full p-2 border rounded border-gray-300"
-            value={imageUrl}
-            onChange={(e) => setImageUrl(e.target.value)}
-            placeholder="https://example.com/image.png"
-          />
-        </div>
+        <ImageUpload
+          label="Cover Image (Optional)"
+          value={imageUrl}
+          onChange={setImageUrl}
+          disabled={isLoading}
+        />
 
         {/* Rich Text Body Field */}
         <div>
@@ -124,7 +117,10 @@ export function NewsForm({
             checked={isPublished}
             onChange={(e) => setIsPublished(e.target.checked)}
           />
-          <label htmlFor="published" className="text-sm font-medium text-gray-700">
+          <label
+            htmlFor="published"
+            className="text-sm font-medium text-gray-700"
+          >
             Publish immediately? (Uncheck to save as draft)
           </label>
         </div>
@@ -144,7 +140,11 @@ export function NewsForm({
             disabled={isLoading}
             className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
           >
-            {isLoading ? "Saving..." : initialData ? "Update Article" : "Create Article"}
+            {isLoading
+              ? "Saving..."
+              : initialData
+                ? "Update Article"
+                : "Create Article"}
           </button>
         </div>
       </form>

--- a/frontend/src/components/admin/SenatorForm.tsx
+++ b/frontend/src/components/admin/SenatorForm.tsx
@@ -4,6 +4,7 @@ import { getDistricts } from "@/lib/api";
 import type { District, Senator } from "@/types";
 import type { CreateSenator, UpdateSenator } from "@/types/admin";
 import { useEffect, useState } from "react";
+import { ImageUpload } from "./ImageUpload";
 
 interface SenatorFormProps {
   initialData?: Senator;
@@ -29,6 +30,7 @@ export function SenatorForm({
   const [sessionNumber, setSessionNumber] = useState(
     initialData?.session_number?.toString() ?? "",
   );
+  const [headshotUrl, setHeadshotUrl] = useState(initialData?.headshot_url ?? "");
   const [isActive, setIsActive] = useState(initialData?.is_active ?? true);
 
   useEffect(() => {
@@ -55,6 +57,7 @@ export function SenatorForm({
       email: email.trim(),
       district_id: Number(districtId),
       session_number: Number(sessionNumber),
+      headshot_url: headshotUrl || null,
     };
 
     if (initialData) {
@@ -154,6 +157,13 @@ export function SenatorForm({
             />
           </div>
         </div>
+
+        <ImageUpload
+          label="Headshot (Optional)"
+          value={headshotUrl}
+          onChange={setHeadshotUrl}
+          disabled={isLoading}
+        />
 
         {initialData ? (
           <div className="flex items-center gap-2">

--- a/frontend/src/components/admin/SenatorForm.tsx
+++ b/frontend/src/components/admin/SenatorForm.tsx
@@ -30,7 +30,9 @@ export function SenatorForm({
   const [sessionNumber, setSessionNumber] = useState(
     initialData?.session_number?.toString() ?? "",
   );
-  const [headshotUrl, setHeadshotUrl] = useState(initialData?.headshot_url ?? "");
+  const [headshotUrl, setHeadshotUrl] = useState(
+    initialData?.headshot_url ?? "",
+  );
   const [isActive, setIsActive] = useState(initialData?.is_active ?? true);
 
   useEffect(() => {

--- a/frontend/src/components/admin/StaffForm.tsx
+++ b/frontend/src/components/admin/StaffForm.tsx
@@ -46,6 +46,7 @@ export function StaffForm({
         last_name: lastName,
         title,
         email,
+        photo_url: photoUrl || null,
         display_order: displayOrder,
       };
       onSubmit(data);

--- a/frontend/src/components/admin/StaffForm.tsx
+++ b/frontend/src/components/admin/StaffForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import type { AdminStaff, CreateStaff, UpdateStaff } from "@/types/admin";
+import { useState } from "react";
+import { ImageUpload } from "./ImageUpload";
 
 interface StaffFormProps {
   initialData?: AdminStaff;
@@ -112,18 +113,12 @@ export function StaffForm({
           />
         </div>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Photo URL (Optional)
-          </label>
-          <input
-            type="url"
-            className="w-full p-2 border rounded border-gray-300"
-            value={photoUrl}
-            onChange={(e) => setPhotoUrl(e.target.value)}
-            placeholder="https://example.com/photo.jpg"
-          />
-        </div>
+        <ImageUpload
+          label="Photo (Optional)"
+          value={photoUrl}
+          onChange={setPhotoUrl}
+          disabled={isLoading}
+        />
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -14,8 +14,8 @@ import type {
 } from "@/types";
 import type {
   Account,
-  AdminLeadership,
   AdminDistrict,
+  AdminLeadership,
   AdminNews,
   AdminStaff,
   AssignCommitteeMember,
@@ -38,8 +38,8 @@ import type {
   LoginResponse,
   UpdateDistrict,
   UpdateFinanceHearingConfig,
-  UpdateLeadership,
   UpdateFinanceHearingDate,
+  UpdateLeadership,
   UpdateNews,
   UpdateSenator,
   UpdateStaff,
@@ -92,6 +92,71 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   if (!rawBody) return undefined as T;
 
   return JSON.parse(rawBody) as T;
+}
+
+export interface UploadImageResponse {
+  url: string;
+}
+
+export async function uploadAdminImage(
+  file: File,
+  onProgress?: (percent: number) => void,
+): Promise<UploadImageResponse> {
+  const token = getToken();
+  const formData = new FormData();
+  formData.append("file", file);
+
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", `${API_BASE}${buildApiPath("/admin/upload")}`);
+
+    if (token) {
+      xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+    }
+
+    xhr.upload.onprogress = (event: ProgressEvent<EventTarget>) => {
+      if (!event.lengthComputable || !onProgress) return;
+      const percent = Math.round((event.loaded / event.total) * 100);
+      onProgress(percent);
+    };
+
+    xhr.onerror = () => {
+      reject(new Error("Upload failed. Please try again."));
+    };
+
+    xhr.onload = () => {
+      const responseText = xhr.responseText || "";
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          const parsed = JSON.parse(responseText) as UploadImageResponse;
+          if (!parsed.url) {
+            reject(new Error("Upload succeeded but no URL was returned."));
+            return;
+          }
+          resolve(parsed);
+        } catch {
+          reject(new Error("Upload succeeded but response parsing failed."));
+        }
+        return;
+      }
+
+      let message = `Upload failed (${xhr.status}).`;
+      if (responseText) {
+        try {
+          const parsed = JSON.parse(responseText) as { detail?: string };
+          if (parsed.detail) {
+            message = parsed.detail;
+          }
+        } catch {
+          message = responseText;
+        }
+      }
+
+      reject(new Error(message));
+    };
+
+    xhr.send(formData);
+  });
 }
 
 // Auth

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -151,6 +151,7 @@ export interface CreateStaff {
   last_name: string;
   title: string;
   email: string;
+  photo_url: string | null;
   display_order: number;
 }
 

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -22,6 +22,7 @@ export interface CreateSenator {
   email: string;
   district_id: number;
   session_number: number;
+  headshot_url?: string | null;
 }
 
 export interface UpdateSenator {
@@ -31,6 +32,7 @@ export interface UpdateSenator {
   district_id?: number;
   is_active?: boolean;
   session_number?: number;
+  headshot_url?: string | null;
 }
 
 export interface CreateNews {


### PR DESCRIPTION
Now that the upload endpoint exists, admin forms that accept images (news, senators, carousel, staff) need file upload fields wired to the API.

Changes:

- Image upload integration in admin forms

Closes #116 
