### PR TITLE
Missing Finance Hearing Config Handling

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,7 +5,7 @@ import FinanceHearingButton from "@/components/home/FinanceHearingButton";
 import RecentNews from "@/components/home/RecentNews";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorMessage from "@/components/ui/ErrorMessage";
-import { getCarousel, getEvents, getFinanceHearings } from "@/lib/api";
+import { ApiError, getCarousel, getEvents, getFinanceHearings } from "@/lib/api";
 
 export const dynamic = "force-dynamic";
 
@@ -32,8 +32,12 @@ export default async function Home() {
 
   try {
     financeHearings = await getFinanceHearings();
-  } catch {
-    financeError = true;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      // no config row exists yet — valid empty state
+    } else {
+      financeError = true;
+    }
   }
 
   return (


### PR DESCRIPTION
The `/api/finance-hearings` endpoint returns a 404 when no configuration row has been seeded in the database. The home page currently treats this as an error and displays "Unable to load finance hearing information. Please try again." — which is misleading since the absence of a config is a valid state (hearings season hasn't been configured yet).

Changes:

- catch apierror and just show output

Closes #152 
