### PR TITLE
Senator List Fails to Load if Any Parallel API Call Errors

### DIFF
--- a/frontend/src/app/senators/contact/page.tsx
+++ b/frontend/src/app/senators/contact/page.tsx
@@ -33,24 +33,46 @@ export default function ContactPage() {
 
   useEffect(() => {
     async function loadData() {
-      try {
-        const [senatorsData, districtsData, leadershipData] = await Promise.all(
-          [getSenators(), getDistricts(), getLeadership()],
-        );
-        setSenators(senatorsData);
-        setDistricts(districtsData);
+      const [senatorsResult, districtsResult, leadershipResult] =
+        await Promise.allSettled([
+          getSenators(),
+          getDistricts(),
+          getLeadership(),
+        ]);
 
-        const currentSpeaker = leadershipData.find(
+      if (senatorsResult.status === "fulfilled") {
+        setSenators(senatorsResult.value);
+      } else {
+        console.error("Failed to load senators", senatorsResult.reason);
+      }
+
+      if (districtsResult.status === "fulfilled") {
+        setDistricts(districtsResult.value);
+      } else {
+        console.error("Failed to load districts", districtsResult.reason);
+      }
+
+      if (leadershipResult.status === "fulfilled") {
+        const currentSpeaker = leadershipResult.value.find(
           (l) => l.is_current && l.title.toLowerCase().includes("speaker"),
         );
         if (currentSpeaker) {
           setSpeaker(currentSpeaker);
         }
-      } catch (err) {
-        console.error("Failed to load contact data", err);
-      } finally {
-        setIsLoadingSenators(false);
+      } else {
+        console.error("Failed to load leadership", leadershipResult.reason);
       }
+
+      if (
+        senatorsResult.status === "rejected" ||
+        districtsResult.status === "rejected"
+      ) {
+        setError(
+          "Some senator information could not be loaded. You can still send a message to speaker@unc.edu directly.",
+        );
+      }
+
+      setIsLoadingSenators(false);
     }
     loadData();
   }, []);


### PR DESCRIPTION
The contact form (`/senators/contact`) fetches senators, districts, and leadership data in a single `Promise.all`. If any one of those three calls fails (for example, if no leadership has been configured yet), the entire batch is aborted and the senator dropdown is never populated — leaving "Speaker of the Senate" as the only selectable recipient, with no error surfaced to the user.

Changes:

- Promise.all replaced by Promise.allSettled

Closes #159 