### PR TITLE
Committee Previews Display Ampersand as `&amp;`

### DIFF
--- a/frontend/src/lib/html.ts
+++ b/frontend/src/lib/html.ts
@@ -1,6 +1,11 @@
 export function stripHtmlTags(value: string): string {
   return value
     .replace(/<[^>]*>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
     .replace(/\s+/g, " ")
     .trim();
 }


### PR DESCRIPTION
The committees listing page (`/committees`) shows a short text preview of each committee's description using `stripHtmlTags`. Because committee descriptions are stored as HTML (produced by the rich text editor), any `&` character is stored as the HTML entity `&amp;`. The `stripHtmlTags` utility in `frontend/src/lib/html.ts` strips HTML tags but does not decode HTML entities, so `&amp;` is displayed literally in the preview card.

Changes:

- HTML stripping function

Closes #161 
