### PR TITLE
Legislation: Add Short Title Field

### DIFF
--- a/backend/app/models/Legislation.py
+++ b/backend/app/models/Legislation.py
@@ -13,6 +13,7 @@ class Legislation(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
+    short_title: Mapped[str | None] = mapped_column(String(255), nullable=True)
     bill_number: Mapped[str] = mapped_column(String(50), nullable=False)
     session_number: Mapped[int] = mapped_column(Integer, nullable=False)
     sponsor_id: Mapped[int | None] = mapped_column(ForeignKey("senator.id"), nullable=True)

--- a/backend/app/schemas/legislation.py
+++ b/backend/app/schemas/legislation.py
@@ -17,6 +17,7 @@ class LegislationActionDTO(BaseModel):
 class LegislationListDTO(BaseModel):
     id: int
     title: str
+    short_title: str | None = None
     bill_number: str
     session_number: int
     sponsor_name: str
@@ -40,6 +41,7 @@ class LegislationDTO(LegislationDetailDTO):
 
 class CreateLegislationDTO(BaseModel):
     title: str
+    short_title: str | None = None
     bill_number: str
     session_number: int
     sponsor_id: int | None
@@ -53,6 +55,7 @@ class CreateLegislationDTO(BaseModel):
 
 class UpdateLegislationDTO(BaseModel):
     title: str | None = None
+    short_title: str | None = None
     bill_number: str | None = None
     session_number: int | None = None
     sponsor_id: int | None = None

--- a/backend/tests/models/test_other_models.py
+++ b/backend/tests/models/test_other_models.py
@@ -81,6 +81,7 @@ class TestLegislationModel:
         expected = {
             "id",
             "title",
+            "short_title",
             "bill_number",
             "session_number",
             "sponsor_id",

--- a/frontend/src/app/legislation/[id]/page.tsx
+++ b/frontend/src/app/legislation/[id]/page.tsx
@@ -80,7 +80,13 @@ export default async function LegislationDetailPage({
         <StatusBadge status={legislation.status} />
       </div>
 
-      <h1 className="text-3xl font-bold mb-4">{legislation.title}</h1>
+      <h1 className="text-3xl font-bold mb-1">{legislation.title}</h1>
+      {legislation.short_title && (
+        <p className="text-lg text-gray-500 italic mb-4">
+          {legislation.short_title}
+        </p>
+      )}
+      {!legislation.short_title && <div className="mb-4" />}
 
       <div className="text-sm text-gray-600 mb-6 space-y-1">
         <p>

--- a/frontend/src/components/admin/LegislationForm.tsx
+++ b/frontend/src/components/admin/LegislationForm.tsx
@@ -31,6 +31,7 @@ export function LegislationForm({
   isLoading = false,
 }: LegislationFormProps) {
   const [title, setTitle] = useState(initialData?.title || "");
+  const [shortTitle, setShortTitle] = useState(initialData?.short_title || "");
   const [billNumber, setBillNumber] = useState(initialData?.bill_number || "");
   const [sessionNumber, setSessionNumber] = useState<number>(
     initialData?.session_number || 1,
@@ -98,6 +99,7 @@ export function LegislationForm({
     e.preventDefault();
     onSubmit({
       title: title.trim(),
+      short_title: shortTitle.trim() || null,
       bill_number: billNumber.trim(),
       session_number: sessionNumber,
       sponsor_id: sponsorId,
@@ -138,6 +140,16 @@ export function LegislationForm({
               onChange={(e) => setTitle(e.target.value)}
             />
           </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="short-title">Short Title (optional)</Label>
+          <Input
+            id="short-title"
+            type="text"
+            value={shortTitle}
+            onChange={(e) => setShortTitle(e.target.value)}
+          />
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -64,6 +64,7 @@ export interface UpdateNews {
 
 export interface CreateLegislation {
   title: string;
+  short_title?: string | null;
   bill_number: string;
   session_number: number;
   sponsor_id: number | null;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -68,6 +68,7 @@ export interface LegislationAction {
 export interface Legislation {
   id: number;
   title: string;
+  short_title?: string | null;
   bill_number: string;
   session_number: number;
   sponsor_name: string;


### PR DESCRIPTION
Bills frequently have two titles: a long formal title (e.g. "A BILL TO ESTABLISH A FUND FOR…") and a short colloquial title (e.g. "The Student Wellness Act"). The current legislation form and database schema only support a single title field, making it impossible to record both.

Changes:

- Changed db schema
- Added frontend types
- Added text input for the short title field

Closes #162 
