### PR TITLE
Legislation: Support PDF Upload for Full Text

### DIFF
--- a/backend/app/models/Legislation.py
+++ b/backend/app/models/Legislation.py
@@ -20,6 +20,7 @@ class Legislation(Base):
     sponsor_name: Mapped[str] = mapped_column(String(255), nullable=False)
     summary: Mapped[str] = mapped_column(Text, nullable=False)
     full_text: Mapped[str] = mapped_column(Text, nullable=False)
+    full_text_pdf_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     status: Mapped[str] = mapped_column(String(50), nullable=False)
     type: Mapped[str] = mapped_column(String(50), nullable=False)
     date_introduced: Mapped[date] = mapped_column(Date, nullable=False)

--- a/backend/app/routers/admin/upload.py
+++ b/backend/app/routers/admin/upload.py
@@ -38,6 +38,21 @@ def _validate_and_load_image(content: bytes) -> tuple[Image.Image, str]:
     return image, _ALLOWED_FORMATS[fmt]
 
 
+def _validate_pdf(content: bytes) -> None:
+    if len(content) > MAX_UPLOAD_SIZE_BYTES:
+        raise HTTPException(status_code=413, detail="File too large. Max size is 5MB")
+    if not content.startswith(b"%PDF-"):
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+
+
+def _save_pdf(content: bytes) -> str:
+    uploads_dir = Path(UPLOAD_DIR)
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+    filename = f"{uuid4().hex}.pdf"
+    (uploads_dir / filename).write_bytes(content)
+    return filename
+
+
 def _save_resized_images(image: Image.Image, extension: str) -> str:
     """Save standard and thumbnail variants and return the main filename."""
     uploads_dir = Path(UPLOAD_DIR)
@@ -78,4 +93,17 @@ async def upload_image(
     content = await file.read()
     image, extension = _validate_and_load_image(content)
     filename = _save_resized_images(image, extension)
+    return {"url": f"{UPLOAD_BASE_URL}/{filename}"}
+
+
+@router.post("/upload/pdf")
+async def upload_pdf(
+    file: UploadFile = File(...),
+    current_user: Admin = Depends(get_current_user),
+):
+    """Upload a PDF and return a relative URL to the stored file."""
+    _ = current_user
+    content = await file.read()
+    _validate_pdf(content)
+    filename = _save_pdf(content)
     return {"url": f"{UPLOAD_BASE_URL}/{filename}"}

--- a/backend/app/routers/legislation.py
+++ b/backend/app/routers/legislation.py
@@ -38,6 +38,7 @@ def _legislation_base_dict(leg: Legislation) -> dict:
         "sponsor_name": leg.sponsor_name,
         "summary": sanitize_html(leg.summary),
         "full_text": sanitize_html(leg.full_text),
+        "full_text_pdf_url": leg.full_text_pdf_url,
         "status": leg.status,
         "type": leg.type,
         "date_introduced": leg.date_introduced,

--- a/backend/app/schemas/legislation.py
+++ b/backend/app/schemas/legislation.py
@@ -23,6 +23,7 @@ class LegislationListDTO(BaseModel):
     sponsor_name: str
     summary: str
     full_text: str
+    full_text_pdf_url: str | None = None
     status: str
     type: str
     date_introduced: date
@@ -48,6 +49,7 @@ class CreateLegislationDTO(BaseModel):
     sponsor_name: str
     summary: str
     full_text: str
+    full_text_pdf_url: str | None = None
     status: str
     type: str
     date_introduced: date
@@ -62,6 +64,7 @@ class UpdateLegislationDTO(BaseModel):
     sponsor_name: str | None = None
     summary: str | None = None
     full_text: str | None = None
+    full_text_pdf_url: str | None = None
     status: str | None = None
     type: str | None = None
     date_introduced: date | None = None

--- a/backend/tests/models/test_other_models.py
+++ b/backend/tests/models/test_other_models.py
@@ -88,6 +88,7 @@ class TestLegislationModel:
             "sponsor_name",
             "summary",
             "full_text",
+            "full_text_pdf_url",
             "status",
             "type",
             "date_introduced",

--- a/frontend/src/app/legislation/[id]/page.tsx
+++ b/frontend/src/app/legislation/[id]/page.tsx
@@ -117,6 +117,16 @@ export default async function LegislationDetailPage({
 
       <section className="mb-8">
         <h2 className="text-xl font-semibold mb-2">Full Text</h2>
+        {legislation.full_text_pdf_url && (
+          <a
+            href={legislation.full_text_pdf_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block mb-3 text-blue-600 hover:underline"
+          >
+            Download Full Text (PDF)
+          </a>
+        )}
         <HtmlContent
           html={legislation.full_text}
           className="prose max-w-none text-gray-700"

--- a/frontend/src/components/admin/LegislationForm.tsx
+++ b/frontend/src/components/admin/LegislationForm.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { getSenators } from "@/lib/api";
+import { uploadAdminPdf } from "@/lib/admin-api";
 import type { Legislation, Senator } from "@/types";
 import type { CreateLegislation } from "@/types/admin";
 import { RichTextEditor } from "./RichTextEditor";
@@ -44,8 +45,32 @@ export function LegislationForm({
   );
   const [summary, setSummary] = useState(initialData?.summary || "");
   const [fullText, setFullText] = useState(initialData?.full_text || "");
+  const [fullTextPdfUrl, setFullTextPdfUrl] = useState(
+    initialData?.full_text_pdf_url || "",
+  );
+  const [isUploadingPdf, setIsUploadingPdf] = useState(false);
+  const [pdfUploadError, setPdfUploadError] = useState<string | null>(null);
   const [status, setStatus] = useState(initialData?.status || "Introduced");
   const [type, setType] = useState(initialData?.type || "Bill");
+
+  const handlePdfChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+
+    setIsUploadingPdf(true);
+    setPdfUploadError(null);
+    try {
+      const { url } = await uploadAdminPdf(file);
+      setFullTextPdfUrl(url);
+    } catch (err) {
+      setPdfUploadError(
+        err instanceof Error ? err.message : "PDF upload failed.",
+      );
+    } finally {
+      setIsUploadingPdf(false);
+    }
+  };
 
   const formatInitialDate = (dateString?: string) => {
     if (!dateString) return "";
@@ -106,6 +131,7 @@ export function LegislationForm({
       sponsor_name: sponsorName.trim(),
       summary: summary.trim(),
       full_text: fullText.trim(),
+      full_text_pdf_url: fullTextPdfUrl || null,
       status,
       type,
       date_introduced: new Date(dateIntroduced).toISOString(),
@@ -244,6 +270,28 @@ export function LegislationForm({
         <div className="space-y-2">
           <Label htmlFor="full-text">Full Text</Label>
           <RichTextEditor value={fullText} onChange={setFullText} />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="full-text-pdf">Full Text PDF (optional)</Label>
+          <input
+            id="full-text-pdf"
+            type="file"
+            accept="application/pdf"
+            onChange={handlePdfChange}
+            disabled={isUploadingPdf}
+          />
+          {isUploadingPdf ? (
+            <p className="text-sm text-gray-600">Uploading...</p>
+          ) : null}
+          {pdfUploadError ? (
+            <p className="text-sm text-red-600">{pdfUploadError}</p>
+          ) : null}
+          {fullTextPdfUrl ? (
+            <p className="text-xs text-gray-500 break-all">
+              Stored URL: {fullTextPdfUrl}
+            </p>
+          ) : null}
         </div>
 
         <div className="flex justify-end gap-3 pt-2">

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -100,7 +100,8 @@ export interface UploadImageResponse {
   url: string;
 }
 
-export async function uploadAdminImage(
+function uploadFile(
+  path: string,
   file: File,
   onProgress?: (percent: number) => void,
 ): Promise<UploadImageResponse> {
@@ -110,7 +111,7 @@ export async function uploadAdminImage(
 
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open("POST", `${API_BASE}${buildApiPath("/admin/upload")}`);
+    xhr.open("POST", `${API_BASE}${buildApiPath(path)}`);
 
     if (token) {
       xhr.setRequestHeader("Authorization", `Bearer ${token}`);
@@ -159,6 +160,20 @@ export async function uploadAdminImage(
 
     xhr.send(formData);
   });
+}
+
+export async function uploadAdminImage(
+  file: File,
+  onProgress?: (percent: number) => void,
+): Promise<UploadImageResponse> {
+  return uploadFile("/admin/upload", file, onProgress);
+}
+
+export async function uploadAdminPdf(
+  file: File,
+  onProgress?: (percent: number) => void,
+): Promise<UploadImageResponse> {
+  return uploadFile("/admin/upload/pdf", file, onProgress);
 }
 
 // Auth

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -71,6 +71,7 @@ export interface CreateLegislation {
   sponsor_name: string;
   summary: string;
   full_text: string;
+  full_text_pdf_url?: string | null;
   status: string;
   type: string;
   date_introduced: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -74,6 +74,7 @@ export interface Legislation {
   sponsor_name: string;
   summary: string;
   full_text: string;
+  full_text_pdf_url?: string | null;
   status: string;
   type: string;
   date_introduced: string;


### PR DESCRIPTION
Legislative full text must preserve precise formatting (indentation, section numbering, tables). The current rich text editor does not reliably maintain this formatting. Allowing a PDF to be uploaded and stored as the canonical full text preserves the document exactly as authored.

Changes:

- Added a `full_text_pdf_url` column to the `Legislation` model and exposed it on the list/create/update DTOs
- Extended the admin upload endpoint to accept `application/pdf` alongside images, skipping the image-resize path for PDFs
- Added a PDF file input to `LegislationForm` that uploads via the existing upload helper and stores the returned URL alongside the rich text body
- On the public legislation detail page, render a download link for the PDF when `full_text_pdf_url` is present

Closes #163