### PR TITLE
Legislation Detail: Long Bill Titles Cause Layout Overflow and Push "Add Action" Out of View

### DIFF
--- a/frontend/src/app/admin/legislation/[id]/page.tsx
+++ b/frontend/src/app/admin/legislation/[id]/page.tsx
@@ -152,6 +152,10 @@ export default function LegislationDetailsPage() {
 
       <AdminCard>
         <div className="grid gap-4 text-sm text-slate-700 sm:grid-cols-2">
+          <p className="sm:col-span-2">
+            <span className="font-semibold text-slate-900">Title:</span>{" "}
+            {legislation.bill_number}: {legislation.title}
+          </p>
           <p>
             <span className="font-semibold text-slate-900">Status:</span>{" "}
             {legislation.status}

--- a/frontend/src/app/admin/legislation/page.tsx
+++ b/frontend/src/app/admin/legislation/page.tsx
@@ -90,7 +90,15 @@ export default function AdminLegislationPage() {
   // Define Table Columns
   const columns: ColumnDef<Legislation>[] = [
     { accessorKey: "bill_number", header: "Bill Number" },
-    { accessorKey: "title", header: "Title" },
+    {
+      accessorKey: "title",
+      header: "Title",
+      cell: ({ getValue }) => (
+        <div className="max-w-xs truncate" title={getValue() as string}>
+          {getValue() as string}
+        </div>
+      ),
+    },
     { accessorKey: "status", header: "Status" },
     { accessorKey: "type", header: "Type" },
     { accessorKey: "session_number", header: "Session" },

--- a/frontend/src/components/admin/AdminPageShell.tsx
+++ b/frontend/src/components/admin/AdminPageShell.tsx
@@ -28,8 +28,10 @@ export function AdminPageHeader({
 }) {
   return (
     <div className="flex flex-col gap-4 border-b border-slate-200 pb-4 sm:flex-row sm:items-start sm:justify-between">
-      <div>
-        <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+      <div className="min-w-0">
+        <h1 className="truncate text-2xl font-semibold text-slate-900">
+          {title}
+        </h1>
         {description ? (
           <p className="mt-1 text-sm text-slate-600">{description}</p>
         ) : null}


### PR DESCRIPTION
The legislation detail admin page renders the full bill number and title concatenated in the page header. When a bill has a long formal title, the heading overflows the layout, pushing content -- including the "Add Action" button -- out of the visible viewport. The legislation list table has the same problem: an unstyled title column can grow wide enough to scroll the Details/Edit/Delete action buttons off-screen.

Changes:

- Added `min-w-0`/`truncate` to the shared `AdminPageHeader` title so long titles no longer force the header row wider than the viewport
- Added the full title to the legislation detail page's metadata card so it's still readable in full
- Added a `max-w`/`truncate` cell renderer (with a hover tooltip showing the full text) to the title column in the legislation list table so action buttons stay visible

Closes #164