### PR TITLE
Admin Events Dashboard: Submitted Events Do Not Appear

### DIFF
--- a/backend/app/routers/admin/events.py
+++ b/backend/app/routers/admin/events.py
@@ -1,5 +1,6 @@
 """Admin calendar event CRUD routes.
 
+GET    /api/admin/events       — list all events, including unpublished ones
 POST   /api/admin/events       — create event; created_by set from JWT
 PUT    /api/admin/events/{id}  — update event fields
 DELETE /api/admin/events/{id}  — delete event (admin role required)
@@ -23,6 +24,16 @@ router = APIRouter(
     prefix="/api/admin/events",
     tags=["admin", "events"],
 )
+
+
+@router.get("", response_model=list[AdminCalendarEventDTO])
+def list_admin_events(
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List all calendar events, including unpublished ones."""
+    events = db.query(CalendarEvent).order_by(CalendarEvent.start_datetime).all()
+    return [AdminCalendarEventDTO.model_validate(e) for e in events]
 
 
 @router.post("", response_model=AdminCalendarEventDTO, status_code=status.HTTP_201_CREATED)


### PR DESCRIPTION
The admin Events page calls `GET /api/admin/events` to populate its table. This route did not exist -- the admin events router only defined `POST`, `PUT`, and `DELETE` -- so the request 405'd, the error was caught silently, and the table always rendered empty even after events were successfully created.

Changes:

- Added a `GET /api/admin/events` route returning all events (published and unpublished), protected by `get_current_user`, sorted by `start_datetime`, using `AdminCalendarEventDTO`
- Left the public `GET /api/events` route (which filters to `is_published == true`) unchanged

Closes #165