### PR TITLE
Admin Carousel Dashboard: Submitted Slides Do Not Appear

### DIFF
--- a/backend/app/routers/admin/carousel.py
+++ b/backend/app/routers/admin/carousel.py
@@ -1,5 +1,6 @@
 """Admin carousel slide CRUD routes.
 
+GET  /api/admin/carousel          — list all slides (including inactive)
 POST /api/admin/carousel          — create slide
 PUT  /api/admin/carousel/reorder  — batch reorder slides by ordered slide_ids list
 PUT  /api/admin/carousel/{id}     — update slide fields
@@ -24,6 +25,16 @@ router = APIRouter(
     prefix="/api/admin/carousel",
     tags=["admin", "carousel"],
 )
+
+
+@router.get("", response_model=list[CarouselSlideDTO])
+def list_admin_slides(
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List all carousel slides, including inactive ones, ordered by display_order."""
+    slides = db.query(CarouselSlide).order_by(CarouselSlide.display_order).all()
+    return [CarouselSlideDTO.model_validate(s) for s in slides]
 
 
 @router.post("", response_model=CarouselSlideDTO, status_code=status.HTTP_201_CREATED)


### PR DESCRIPTION
The admin Carousel page calls `GET /api/admin/carousel` to populate its slide list. This route did not exist -- the admin carousel router only defined `POST`, `PUT /reorder`, `PUT /{id}`, and `DELETE /{id}` -- so the request 405'd, the error was caught silently, and the list always rendered empty even after slides were created.

Changes:

- Added a `GET /api/admin/carousel` route returning all slides (active and inactive) ordered by `display_order`, protected by `get_current_user`, mirroring the list-all pattern used by every other admin router
- Left the public `GET /api/carousel` route (which filters to `is_active == true`) unchanged
- Confirmed the new route doesn't conflict with `PUT /reorder` (different HTTP method, same prefix)

Closes #166