### PR TITLE
Public Calendar: Finance Hearing Timeslots Not Shown

### DIFF
--- a/frontend/src/app/meetings/page.tsx
+++ b/frontend/src/app/meetings/page.tsx
@@ -1,18 +1,28 @@
 import CalendarWidget from "@/components/calendar/CalendarWidget";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorMessage from "@/components/ui/ErrorMessage";
-import { getEvents } from "@/lib/api";
+import { getEvents, getFinanceHearings } from "@/lib/api";
+import { financeHearingsToCalendarEvents } from "@/lib/calendar";
 
 export const dynamic = "force-dynamic";
 
 export default async function MeetingsPage() {
   let events: Awaited<ReturnType<typeof getEvents>> = [];
+  let financeHearings: Awaited<ReturnType<typeof getFinanceHearings>> | null =
+    null;
   let hasError = false;
 
   try {
     events = await getEvents();
   } catch {
     hasError = true;
+  }
+
+  try {
+    financeHearings = await getFinanceHearings();
+  } catch {
+    // Finance hearings are optional — tolerate failure and fall back to
+    // showing only regular events.
   }
 
   if (hasError) {
@@ -25,16 +35,23 @@ export default async function MeetingsPage() {
     );
   }
 
+  const calendarEvents = [
+    ...events,
+    ...(financeHearings
+      ? financeHearingsToCalendarEvents(financeHearings.dates)
+      : []),
+  ];
+
   return (
     <section className="min-h-screen bg-gray-50">
       <div className="container mx-auto px-4 py-12">
-        {events.length === 0 ? (
+        {calendarEvents.length === 0 ? (
           <EmptyState
             message="No meetings available right now."
             description="Check back soon for upcoming meeting dates and details."
           />
         ) : (
-          <CalendarWidget events={events} compact={false} />
+          <CalendarWidget events={calendarEvents} compact={false} />
         )}
       </div>
     </section>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,6 +6,7 @@ import RecentNews from "@/components/home/RecentNews";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorMessage from "@/components/ui/ErrorMessage";
 import { ApiError, getCarousel, getEvents, getFinanceHearings } from "@/lib/api";
+import { financeHearingsToCalendarEvents } from "@/lib/calendar";
 
 export const dynamic = "force-dynamic";
 
@@ -40,6 +41,13 @@ export default async function Home() {
     }
   }
 
+  const calendarEvents = [
+    ...events,
+    ...(financeHearings
+      ? financeHearingsToCalendarEvents(financeHearings.dates)
+      : []),
+  ];
+
   return (
     <div className="min-h-screen bg-gray-50">
       {carouselError ? (
@@ -71,7 +79,7 @@ export default async function Home() {
                 description="Check back soon for the latest calendar updates."
               />
             ) : (
-              <CalendarWidget events={events} compact={true} />
+              <CalendarWidget events={calendarEvents} compact={true} />
             )}
           </div>
         </div>

--- a/frontend/src/lib/calendar.ts
+++ b/frontend/src/lib/calendar.ts
@@ -1,0 +1,32 @@
+import type { CalendarEvent, FinanceHearingDate } from "@/types";
+
+const FINANCE_HEARING_ID_OFFSET = 1000000;
+const DEFAULT_DURATION_MINUTES = 30;
+
+/**
+ * Converts a finance hearing date into a synthetic CalendarEvent so it can
+ * be rendered alongside regular events in CalendarWidget.
+ */
+export function financeHearingToCalendarEvent(
+  hearing: FinanceHearingDate,
+): CalendarEvent {
+  const start = new Date(`${hearing.hearing_date}T${hearing.hearing_time}`);
+  const end = new Date(start.getTime() + DEFAULT_DURATION_MINUTES * 60 * 1000);
+
+  return {
+    id: FINANCE_HEARING_ID_OFFSET + hearing.id,
+    title: `Finance Hearing${hearing.is_full ? " (Full)" : ""}`,
+    description: hearing.description,
+    start_datetime: start.toISOString(),
+    end_datetime: end.toISOString(),
+    location: hearing.location,
+    event_type: "Finance Hearing",
+    is_published: true,
+  };
+}
+
+export function financeHearingsToCalendarEvents(
+  hearings: FinanceHearingDate[],
+): CalendarEvent[] {
+  return hearings.map(financeHearingToCalendarEvent);
+}


### PR DESCRIPTION
Finance hearing dates are managed through a dedicated admin panel and stored as `FinanceHearingDate` records, separate from the `CalendarEvent` model. The public meetings/calendar page only fetches `CalendarEvent` records, so scheduled finance hearing timeslots never appeared on the public-facing calendar.

Changes:

- Added a shared mapper (`financeHearingsToCalendarEvents`) that transforms `FinanceHearingDate` records into synthetic `CalendarEvent`-shaped objects (id offset to avoid collisions, 30-minute slot, title suffixed `" (Full)"` when `is_full` is true)
- Fetched finance hearings on the meetings page (tolerating failure, same as the homepage already does) and merged them into the events passed to `CalendarWidget`
- Applied the same merge on the homepage, which already fetched finance hearings for the `FinanceHearingButton` but never passed them to the calendar

Closes #167