### PR TITLE
Budget Breakdown: Dollar Amounts Should Not Round to Nearest Dollar

### DIFF
--- a/frontend/src/app/funding/budget/page.tsx
+++ b/frontend/src/app/funding/budget/page.tsx
@@ -69,7 +69,8 @@ export default function FundingBudgetPage() {
     return new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: "USD",
-      maximumFractionDigits: 0,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
     }).format(value);
   }
 


### PR DESCRIPTION
The budget breakdown page formats all amounts using `maximumFractionDigits: 0`, which rounds every value to the nearest whole dollar. Budget figures are entered as per-student amounts (e.g. $4.23 per student), so rounding introduces meaningful inaccuracy in how the numbers are displayed.

Changes:

- Updated `formatCurrency` in `frontend/src/app/funding/budget/page.tsx` to use `minimumFractionDigits: 2` / `maximumFractionDigits: 2`, fixing the treemap tooltip, total summary, and breakdown list (all share this one function)

Closes #168