### PR TITLE
Legislation Submission Fails With a Database Error

### DIFF
--- a/backend/script/init_db.py
+++ b/backend/script/init_db.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 import os
 import sys
 
-from sqlalchemy import or_
+from sqlalchemy import inspect, or_, text
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.schema import CreateColumn
 
 from app.database import (
     Base,
@@ -30,6 +31,40 @@ from app.utils.passwords import hash_password
 def create_missing_tables() -> None:
     Base.metadata.create_all(bind=engine)
     print("Missing tables created")
+
+
+def sync_missing_columns() -> None:
+    """Add columns present on the ORM models but missing from deployed tables.
+
+    create_all() only creates tables that don't exist yet; it never alters a
+    table that's already there. When a column is added to a model whose table
+    was already deployed, the deployed table silently falls out of sync and
+    any insert/update touching that column fails at the database level. This
+    brings existing tables' columns back in line with the models.
+    """
+    inspector = inspect(engine)
+    existing_tables = set(inspector.get_table_names())
+
+    with engine.begin() as conn:
+        for table in Base.metadata.sorted_tables:
+            if table.name not in existing_tables:
+                continue  # just created by create_missing_tables()
+
+            existing_columns = {col["name"] for col in inspector.get_columns(table.name)}
+            for column in table.columns:
+                if column.name in existing_columns:
+                    continue
+
+                if not column.nullable and column.default is None and column.server_default is None:
+                    print(
+                        f"Skipping {table.name}.{column.name}: NOT NULL with no default, "
+                        "cannot be added automatically to a table with existing rows"
+                    )
+                    continue
+
+                column_ddl = CreateColumn(column).compile(dialect=engine.dialect)
+                conn.execute(text(f"ALTER TABLE {table.name} ADD COLUMN {column_ddl}"))
+                print(f"Added missing column {table.name}.{column.name}")
 
 
 def bootstrap_initial_admin() -> None:
@@ -96,5 +131,6 @@ def bootstrap_initial_admin() -> None:
 if __name__ == "__main__":
     print("Initializing deployed database")
     create_missing_tables()
+    sync_missing_columns()
     bootstrap_initial_admin()
     print("Database initialization complete")


### PR DESCRIPTION
Submitting new legislation from the admin panel throws an error instead of saving. The `Legislation` model has columns (`short_title` added in #175, `full_text_pdf_url` added in #176) that were added to the SQLAlchemy model, but this repo has no migration system — `backend/script/init_db.py` and `backend/script/create_db.py` both rely solely on `Base.metadata.create_all()`, which only creates missing tables and never alters columns on a table that already exists. Since the `legislation` table already existed in the deployed database before these columns were added, the deployed table is missing them, so every insert/update through `create_legislation`/`update_legislation` fails at the database layer. Reproduced locally: recreating the pre-#175 schema and running current code against it throws `OperationalError: table legislation has no column named short_title`.

Changes:

- Init db change

Closes #182 
