### PR TITLE
Fix finance hearing banner copy on homepage

### DIFF
--- a/frontend/src/components/home/FinanceHearingButton.tsx
+++ b/frontend/src/components/home/FinanceHearingButton.tsx
@@ -11,20 +11,20 @@ export default function FinanceHearingButton({
     <Link
       href={href}
       className="group block rounded-lg border border-slate-300 bg-white p-5 transition hover:bg-slate-50"
-      aria-label="View available finance hearing dates"
+      aria-label="Learn how to apply for organization funding"
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <p className="text-sm font-medium text-slate-700">Funding Season</p>
+          <p className="text-sm font-medium text-slate-700">Funding</p>
           <h2 className="text-xl font-semibold text-slate-900">
-            Schedule Your Finance Hearing
+            Apply for Organization Funding
           </h2>
           <p className="mt-1 text-sm text-slate-600">
-            See open hearing dates and reserve a spot before they fill.
+            See how to apply and what the finance hearing process involves.
           </p>
         </div>
         <span className="inline-flex shrink-0 items-center justify-center rounded-md bg-slate-900 px-4 py-1.5 text-sm font-medium text-white transition group-hover:bg-slate-700">
-          View Dates
+          Learn More
         </span>
       </div>
     </Link>


### PR DESCRIPTION
## Summary
- The homepage "Finance Hearing" banner linked to the correct funding application page, but its copy ("Schedule Your Finance Hearing", "reserve a spot before they fill", "View Dates") implied hearing slots are currently bookable, which isn't accurate right now.
- Updated the copy to point people to the funding process without implying urgency/availability that isn't there. Link destination is unchanged.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` passes
- [ ] Backend ruff/pytest hooks didn't run locally (this repo's pre-commit config needs the Linux devcontainer — `pytest`'s `--basetemp=/dev/shm/pytest` doesn't exist on macOS); change doesn't touch backend code, CI should still run them here
- [ ] @calebyhan to review

🤖 Generated with [Claude Code](https://claude.com/claude-code)