### PR TITLE
Add index page for /funding route

### DIFF
--- a/frontend/src/app/funding/page.tsx
+++ b/frontend/src/app/funding/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
+
+export default function FundingPage() {
+  redirect("/funding/apply");
+}


### PR DESCRIPTION
frontend/src/app/funding/ only has subroutes (apply, budget, budget-process) -- there was no page.tsx for the bare /funding path, so direct navigation or a deep link to it 404'd.

Changes:

- Added frontend/src/app/funding/page.tsx that redirects to /funding/apply, matching the existing precedent at frontend/src/app/legislation/page.tsx

Closes #186
