### PR TITLE
Trust OpenShift router's forwarded headers so backend redirects use https

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,4 +27,4 @@ RUN mkdir -p /app/uploads \
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "python -m script.init_db && uvicorn app.main:app --host 0.0.0.0 --port ${PORT} --proxy-headers"]
+CMD ["sh", "-c", "python -m script.init_db && uvicorn app.main:app --host 0.0.0.0 --port ${PORT} --proxy-headers --forwarded-allow-ips='*'"]


### PR DESCRIPTION
uvicorn already ran with --proxy-headers, but its ProxyHeadersMiddleware defaults --forwarded-allow-ips to 127.0.0.1, so it never trusted the X-Forwarded-Proto header coming from OpenShift's router (which connects over the cluster network, not localhost) and fell back to scheme http for its own trailing-slash redirects. Browsers block HTTPS->HTTP redirects as mixed content, so client-side fetches like getLeadership() on /senators/contact failed silently for real users.

Changes:

- Added --forwarded-allow-ips='*' to the uvicorn CMD in backend/Dockerfile

Closes #187
