### PR TITLE
Fix stale staff, leadership, and funding hearing pages

### DIFF
--- a/frontend/src/app/about/staff/page.tsx
+++ b/frontend/src/app/about/staff/page.tsx
@@ -4,6 +4,8 @@ import { IMAGE_PATHS } from "@/lib/imagePaths";
 import { loadStaffForPage } from "@/lib/staff";
 import Image from "next/image";
 
+export const dynamic = "force-dynamic";
+
 export default async function StaffPage() {
   const staff = await loadStaffForPage(() => getStaff());
 

--- a/frontend/src/app/funding/apply/page.tsx
+++ b/frontend/src/app/funding/apply/page.tsx
@@ -1,6 +1,8 @@
 import StaticPage from "@/components/StaticPage";
 import { getFinanceHearings } from "@/lib/api";
 
+export const dynamic = "force-dynamic";
+
 function formatHearingDate(dateString: string): string {
   const parsed = new Date(`${dateString}T12:00:00`);
   if (Number.isNaN(parsed.getTime())) return dateString;

--- a/frontend/src/app/senators/leadership/page.tsx
+++ b/frontend/src/app/senators/leadership/page.tsx
@@ -5,6 +5,8 @@ import { IMAGE_PATHS } from "@/lib/imagePaths";
 import { loadLeadershipForPage } from "@/lib/leadership";
 import Image from "next/image";
 
+export const dynamic = "force-dynamic";
+
 export default async function LeadershipPage() {
   const leadership = await loadLeadershipForPage(() => getLeadership());
 


### PR DESCRIPTION
## Summary
- Fixes #191: staff and leadership updates made in the admin panel never appeared on the public site.
- Root cause: `about/staff`, `senators/leadership`, and `funding/apply` fetch admin-editable data as async Server Components without opting out of Next.js's default fetch caching. This app deploys as a long-lived Docker build rather than rebuilding per request, so these pages were statically frozen at build time.
- `funding/apply` (finance hearing dates) had the identical gap — not reported, found while fixing #191, included since it's the same root cause and same one-line fix.
- Fix matches the pattern already used correctly on the homepage (`export const dynamic = "force-dynamic"`).

## Test plan
- [x] `tsc --noEmit` passes
- [x] `next build` confirms all three routes flip from static (○) to dynamic (ƒ)
- [ ] Backend hooks skipped — no backend files touched; same pre-existing macOS/devcontainer pytest gap noted on #192
- [ ] @calebyhan / @lpkiley to confirm staff/leadership updates now show up live after this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)