### PR TITLE
Catch DecompressionBombError on image upload

### DIFF
--- a/backend/app/routers/admin/upload.py
+++ b/backend/app/routers/admin/upload.py
@@ -28,7 +28,7 @@ def _validate_and_load_image(content: bytes) -> tuple[Image.Image, str]:
     try:
         image = Image.open(BytesIO(content))
         image.load()
-    except (UnidentifiedImageError, OSError) as exc:
+    except (UnidentifiedImageError, OSError, Image.DecompressionBombError) as exc:
         raise HTTPException(status_code=400, detail="Unsupported file type") from exc
 
     fmt = (image.format or "").upper()

--- a/backend/tests/routers/test_admin_upload.py
+++ b/backend/tests/routers/test_admin_upload.py
@@ -75,6 +75,24 @@ def test_invalid_file_type(admin_client, tmp_path, monkeypatch):
     assert response.json()["detail"] == "Unsupported file type"
 
 
+def test_decompression_bomb_rejected_cleanly(admin_client, tmp_path, monkeypatch):
+    from PIL import Image as PILImage
+
+    from app.routers.admin import upload as upload_router
+
+    monkeypatch.setattr(upload_router, "UPLOAD_DIR", str(tmp_path))
+    monkeypatch.setattr(PILImage, "MAX_IMAGE_PIXELS", 1000)
+
+    payload = _make_png_bytes(width=200, height=200)
+    response = admin_client.post(
+        "/api/admin/upload",
+        files={"file": ("huge.png", payload, "image/png")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Unsupported file type"
+
+
 def test_oversized_file(admin_client, tmp_path, monkeypatch):
     from app.routers.admin import upload as upload_router
 


### PR DESCRIPTION
## Summary
- Fixes #188: `_validate_and_load_image` only caught `(UnidentifiedImageError, OSError)`. Pillow's `DecompressionBombError` is a plain `Exception`, not `OSError` (confirmed via class MRO), so a crafted small-file/huge-declared-dimensions image crashed with a raw 500 instead of a clean 400.
- Added `Image.DecompressionBombError` to the caught exception tuple.
- Added a regression test that lowers `MAX_IMAGE_PIXELS` and confirms the endpoint now returns a clean 400 instead of crashing.

## Test plan
- [x] `pytest tests/routers/test_admin_upload.py` — 5/5 pass (native macOS venv, repo's committed `.venv` is devcontainer-only and can't run here)
- [x] `ruff check` on the changed file — clean
- [ ] Full pre-commit hooks skipped — same pre-existing Linux-only pytest `basetemp` gap noted on #192/#196, unrelated to this change
- [ ] @calebyhan to review

🤖 Generated with [Claude Code](https://claude.com/claude-code)