### PR TITLE
Add auth-rejection tests for admin upload endpoints

### DIFF
--- a/backend/tests/routers/test_admin_upload.py
+++ b/backend/tests/routers/test_admin_upload.py
@@ -90,6 +90,23 @@ def test_oversized_file(admin_client, tmp_path, monkeypatch):
     assert response.json()["detail"] == "File too large. Max size is 5MB"
 
 
+def test_unauthenticated_image_upload_rejected(client):
+    payload = _make_png_bytes()
+    response = client.post(
+        "/api/admin/upload",
+        files={"file": ("headshot.png", payload, "image/png")},
+    )
+    assert response.status_code in {401, 403}
+
+
+def test_unauthenticated_pdf_upload_rejected(client):
+    response = client.post(
+        "/api/admin/upload/pdf",
+        files={"file": ("doc.pdf", b"%PDF-1.4\n%fake", "application/pdf")},
+    )
+    assert response.status_code in {401, 403}
+
+
 def test_standard_resize_only_limits_width(admin_client, tmp_path, monkeypatch):
     from app.routers.admin import upload as upload_router
 


### PR DESCRIPTION
## Summary
- Fixes #189: `test_admin_upload.py` was the only admin router test file with no coverage proving unauthenticated requests get rejected — every other admin router's test file has this.
- Added two tests (image upload, PDF upload) asserting a 401/403 with no auth token.
- Note: the underlying auth dependency was already present in both route signatures — this closes a test-coverage gap, it doesn't fix a live vulnerability. Both tests pass unchanged against existing code.

## Test plan
- [x] `pytest tests/routers/test_admin_upload.py` — 6/6 pass (native macOS venv)
- [x] `ruff check` — clean
- [ ] Full pre-commit hooks skipped — same pre-existing Linux-only pytest `basetemp` gap noted on #192/#196/#197
- [ ] @calebyhan to review

🤖 Generated with [Claude Code](https://claude.com/claude-code)