### PR TITLE
Fix admin table columns hidden on overflow instead of scrollable

### DIFF
--- a/frontend/src/components/admin/DataTable.tsx
+++ b/frontend/src/components/admin/DataTable.tsx
@@ -51,8 +51,8 @@ export function DataTable<TData, TValue>({
         className="max-w-sm"
       />
 
-      <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
-        <table className="w-full text-sm text-left">
+      <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+        <table className="w-full min-w-max text-sm text-left">
           <thead className="border-b border-slate-200 bg-slate-50">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>


### PR DESCRIPTION
## Summary
- `DataTable.tsx` clipped table overflow with `overflow-hidden` instead of allowing horizontal scroll, and cells use `whitespace-nowrap`, so long field values pushed trailing columns (type/status/actions) off-screen with no way to reach them.
- Switched the container to `overflow-x-auto` (dropping `overflow-hidden`) and added `min-w-max` to the table so it doesn't compress below content width.
- This is a shared component used by all 9 admin tables (events, senators, legislation, news, districts, accounts, leadership, static-pages, staff), so the fix applies everywhere at once.

Fixes #199

## Test plan
- [x] `tsc --noEmit` passes
- [x] Frontend build passes
- [ ] Manually verify the events table (and a couple others) scroll horizontally on a narrow viewport instead of hiding the actions column