### PR TITLE
Fix legislation action dates displaying one day early

### DIFF
--- a/frontend/src/app/admin/legislation/[id]/page.tsx
+++ b/frontend/src/app/admin/legislation/[id]/page.tsx
@@ -225,7 +225,11 @@ export default function LegislationDetailsPage() {
                     <>
                       <div className="flex justify-between">
                         <strong className="text-slate-900">
-                          {new Date(action.action_date).toLocaleDateString()} -{" "}
+                          {new Date(action.action_date).toLocaleDateString(
+                            "en-US",
+                            { timeZone: "UTC" },
+                          )}{" "}
+                          -{" "}
                           {action.action_type}
                         </strong>
                         <div className="flex gap-3 text-xs font-medium">


### PR DESCRIPTION
## Summary
- Action dates are stored as UTC midnight (`new Date(dateString).toISOString()` on a bare `YYYY-MM-DD` input from the date picker).
- The actions timeline rendered them with `toLocaleDateString()` with no timezone, which uses the browser's local timezone — for any US timezone (behind UTC), UTC midnight rolls back to the previous local day.
- Fixed by formatting with `timeZone: "UTC"`, matching the pattern already used correctly on the public legislation search page.

Fixes #200

## Test plan
- [x] `tsc --noEmit` passes
- [x] Frontend build passes
- [ ] Manually add an action with a specific date on the admin legislation page and confirm the timeline shows the same date entered