### PR TITLE
Centralize dynamic-rendering opt-out in fetchAPI instead of per-page

### DIFF
--- a/frontend/src/app/about/staff/page.tsx
+++ b/frontend/src/app/about/staff/page.tsx
@@ -4,8 +4,6 @@ import { IMAGE_PATHS } from "@/lib/imagePaths";
 import { loadStaffForPage } from "@/lib/staff";
 import Image from "next/image";
 
-export const dynamic = "force-dynamic";
-
 export default async function StaffPage() {
   const staff = await loadStaffForPage(() => getStaff());
 

--- a/frontend/src/app/committees/[id]/page.tsx
+++ b/frontend/src/app/committees/[id]/page.tsx
@@ -12,8 +12,6 @@ import {
 import { ApiError, getCommitteeById } from "@/lib/api";
 import { notFound } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-
 export default async function CommitteeDetailPage({
   params,
 }: {

--- a/frontend/src/app/committees/page.tsx
+++ b/frontend/src/app/committees/page.tsx
@@ -13,8 +13,6 @@ import { getCommittees } from "@/lib/api";
 import { stripHtmlTags } from "@/lib/html";
 import Link from "next/link";
 
-export const dynamic = "force-dynamic";
-
 export default async function CommitteesPage() {
   let committees;
   try {

--- a/frontend/src/app/funding/apply/page.tsx
+++ b/frontend/src/app/funding/apply/page.tsx
@@ -1,8 +1,6 @@
 import StaticPage from "@/components/StaticPage";
 import { getFinanceHearings } from "@/lib/api";
 
-export const dynamic = "force-dynamic";
-
 function formatHearingDate(dateString: string): string {
   const parsed = new Date(`${dateString}T12:00:00`);
   if (Number.isNaN(parsed.getTime())) return dateString;

--- a/frontend/src/app/funding/page.tsx
+++ b/frontend/src/app/funding/page.tsx
@@ -1,7 +1,5 @@
 import { redirect } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-
 export default function FundingPage() {
   redirect("/funding/apply");
 }

--- a/frontend/src/app/legislation/[id]/page.tsx
+++ b/frontend/src/app/legislation/[id]/page.tsx
@@ -4,8 +4,6 @@ import type { Legislation, LegislationAction } from "@/types";
 import { format, parseISO } from "date-fns";
 import { notFound } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-
 const STATUS_STYLES: Record<string, string> = {
   Passed: "bg-green-100 text-green-800",
   Failed: "bg-red-100 text-red-800",

--- a/frontend/src/app/legislation/nominations/page.tsx
+++ b/frontend/src/app/legislation/nominations/page.tsx
@@ -5,8 +5,6 @@ import type { Legislation } from "@/types";
 import { format, parseISO } from "date-fns";
 import Link from "next/link";
 
-export const dynamic = "force-dynamic";
-
 const STATUS_STYLES: Record<string, string> = {
   Passed: "bg-green-100 text-green-800",
   Failed: "bg-red-100 text-red-800",

--- a/frontend/src/app/legislation/page.tsx
+++ b/frontend/src/app/legislation/page.tsx
@@ -1,7 +1,5 @@
 import { redirect } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-
 export default function LegislationPage() {
   redirect("/legislation/search");
 }

--- a/frontend/src/app/legislation/recent/page.tsx
+++ b/frontend/src/app/legislation/recent/page.tsx
@@ -5,8 +5,6 @@ import type { Legislation } from "@/types";
 import { format, parseISO } from "date-fns";
 import Link from "next/link";
 
-export const dynamic = "force-dynamic";
-
 const STATUS_STYLES: Record<string, string> = {
   Passed: "bg-green-100 text-green-800",
   Failed: "bg-red-100 text-red-800",

--- a/frontend/src/app/legislation/search/page.tsx
+++ b/frontend/src/app/legislation/search/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-export const dynamic = "force-dynamic";
-
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorMessage from "@/components/ui/ErrorMessage";
 import LoadingSpinner from "@/components/ui/LoadingSpinner";

--- a/frontend/src/app/meetings/page.tsx
+++ b/frontend/src/app/meetings/page.tsx
@@ -4,8 +4,6 @@ import ErrorMessage from "@/components/ui/ErrorMessage";
 import { getEvents, getFinanceHearings } from "@/lib/api";
 import { financeHearingsToCalendarEvents } from "@/lib/calendar";
 
-export const dynamic = "force-dynamic";
-
 export default async function MeetingsPage() {
   let events: Awaited<ReturnType<typeof getEvents>> = [];
   let financeHearings: Awaited<ReturnType<typeof getFinanceHearings>> | null =

--- a/frontend/src/app/news/[id]/page.tsx
+++ b/frontend/src/app/news/[id]/page.tsx
@@ -5,8 +5,6 @@ import { format } from "date-fns";
 import Image from "next/image";
 import { notFound } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-
 export default async function NewsDetailPage({
   params,
 }: {

--- a/frontend/src/app/news/page.tsx
+++ b/frontend/src/app/news/page.tsx
@@ -10,8 +10,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { Suspense } from "react";
 
-export const dynamic = "force-dynamic";
-
 export default async function NewsPage({
   searchParams,
 }: {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,8 +8,6 @@ import ErrorMessage from "@/components/ui/ErrorMessage";
 import { ApiError, getCarousel, getEvents, getFinanceHearings } from "@/lib/api";
 import { financeHearingsToCalendarEvents } from "@/lib/calendar";
 
-export const dynamic = "force-dynamic";
-
 export default async function Home() {
   let slides: Awaited<ReturnType<typeof getCarousel>> = [];
   let events: Awaited<ReturnType<typeof getEvents>> = [];

--- a/frontend/src/app/senators/[id]/page.tsx
+++ b/frontend/src/app/senators/[id]/page.tsx
@@ -11,8 +11,6 @@ import { ApiError, getSenatorById } from "@/lib/api";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-
 function initials(name: string) {
   return name
     .split(" ")

--- a/frontend/src/app/senators/leadership/page.tsx
+++ b/frontend/src/app/senators/leadership/page.tsx
@@ -5,8 +5,6 @@ import { IMAGE_PATHS } from "@/lib/imagePaths";
 import { loadLeadershipForPage } from "@/lib/leadership";
 import Image from "next/image";
 
-export const dynamic = "force-dynamic";
-
 export default async function LeadershipPage() {
   const leadership = await loadLeadershipForPage(() => getLeadership());
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -117,7 +117,7 @@ export async function fetchAPI<T>(
 
   let response: Response;
   try {
-    response = await fetch(url, options);
+    response = await fetch(url, { cache: "no-store", ...options });
   } catch (error) {
     throw new ApiError(0, "Network request failed", error);
   }


### PR DESCRIPTION
## Summary
- `fetchAPI` never set `cache: "no-store"`, so Next statically froze data at build time unless a page remembered to add `export const dynamic = "force-dynamic";` — that line had been duplicated across 16 files with nothing enforcing it, and kept getting reintroduced page-by-page (#191, #192, #196).
- Set `cache: "no-store"` as the default in `fetchAPI` itself (still overridable per-call via `options`), so any page calling an API getter is dynamic automatically.
- Removed the now-redundant `export const dynamic = "force-dynamic";` from all 16 pages, since none of them rely on cookies/headers for dynamic behavior — they all get it from `fetchAPI` now.

Fixes #201

## Test plan
- [x] `tsc --noEmit` passes
- [x] Frontend build passes
- [ ] Verify a page reading admin-edited data (e.g. senators) reflects an edit without a rebuild