### PR TITLE
Add dev-side pageview analytics via proxy.ts + Postgres, with an Admin Analytics tab

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,6 +29,9 @@ INITIAL_ADMIN_FIRST_NAME=
 INITIAL_ADMIN_LAST_NAME=
 INITIAL_ADMIN_ROLE=admin
 
+# Analytics (dev-side pageview tracking, shared with the frontend's proxy.ts)
+ANALYTICS_INGEST_SECRET=replace-with-a-long-random-secret
+
 # Email / SMTP Configuration
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,6 +34,8 @@ UPLOAD_DIR = os.getenv("UPLOAD_DIR", "/app/uploads")
 UPLOAD_BASE_URL = os.getenv("UPLOAD_BASE_URL", "/api/uploads")
 MAX_UPLOAD_SIZE_BYTES = int(os.getenv("MAX_UPLOAD_SIZE_BYTES", str(5 * 1024 * 1024)))
 
+ANALYTICS_INGEST_SECRET = os.getenv("ANALYTICS_INGEST_SECRET")
+
 SMTP_HOST = os.getenv("SMTP_HOST")
 SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
 SMTP_USER = os.getenv("SMTP_USER")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import CORS_ORIGINS
 from app.routers import (
+    analytics,
     auth,
     budget,
     carousel,
@@ -24,6 +25,7 @@ from app.routers import (
     uploads,
 )
 from app.routers.admin import accounts as admin_accounts
+from app.routers.admin import analytics as admin_analytics
 from app.routers.admin import budget as admin_budget
 from app.routers.admin import carousel as admin_carousel
 from app.routers.admin import committees as admin_committees
@@ -74,6 +76,7 @@ app.include_router(legislation.router)
 app.include_router(uploads.router)
 app.include_router(admin_news.router)
 app.include_router(contact.router)
+app.include_router(analytics.router)
 
 
 # Include Admin routers
@@ -91,6 +94,7 @@ app.include_router(admin_districts.router)
 app.include_router(admin_district_mapping.router)
 app.include_router(admin_accounts.router)
 app.include_router(admin_upload.router)
+app.include_router(admin_analytics.router)
 
 
 @app.get("/")

--- a/backend/app/models/PageView.py
+++ b/backend/app/models/PageView.py
@@ -1,0 +1,32 @@
+"""PageView model — server-side pageview analytics captured via Next.js proxy.
+
+visitor_hash is a daily-rotating, non-reversible hash (never a raw IP or a
+cookie), used only to approximate unique visitor counts.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+class PageView(Base):
+    __tablename__ = "page_view"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    path: Mapped[str] = mapped_column(String(500), nullable=False)
+    referrer_host: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    visitor_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        Index("ix_page_view_created_at", "created_at"),
+        Index("ix_page_view_path", "path"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<PageView id={self.id} path={self.path!r} created_at={self.created_at}>"

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from .FinanceHearingDate import FinanceHearingDate
 from .Leadership import Leadership
 from .Legislation import Legislation
 from .LegislationAction import LegislationAction
+from .PageView import PageView
 from .Sections import AdminSections, Sections
 from .Senator import Senator
 
@@ -38,4 +39,5 @@ __all__ = [
     "Leadership",
     "Sections",
     "AdminSections",
+    "PageView",
 ]

--- a/backend/app/routers/admin/analytics.py
+++ b/backend/app/routers/admin/analytics.py
@@ -1,0 +1,80 @@
+"""Admin analytics routes.
+
+GET /api/admin/analytics/summary — aggregated pageview stats for the dashboard
+"""
+
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.models.Admin import Admin
+from app.models.PageView import PageView
+from app.schemas.analytics import (
+    AnalyticsSummaryDTO,
+    DailyPageViewCountDTO,
+    TopPathDTO,
+    TopReferrerDTO,
+)
+
+router = APIRouter(prefix="/api/admin/analytics", tags=["admin", "analytics"])
+
+TOP_N = 10
+
+
+@router.get("/summary", response_model=AnalyticsSummaryDTO)
+def get_analytics_summary(
+    days: int = Query(default=7, ge=1, le=90, description="Number of trailing days to summarize"),
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Aggregate pageview stats over the trailing `days` days."""
+    cutoff = datetime.now() - timedelta(days=days)
+    in_range = PageView.created_at >= cutoff
+
+    total_pageviews = db.query(PageView).filter(in_range).count()
+    unique_visitors = (
+        db.query(PageView.visitor_hash).filter(in_range).distinct().count()
+    )
+
+    day_col = func.date(PageView.created_at).label("day")
+    daily_rows = (
+        db.query(day_col, func.count(PageView.id).label("count"))
+        .filter(in_range)
+        .group_by(day_col)
+        .order_by(day_col)
+        .all()
+    )
+
+    top_path_rows = (
+        db.query(PageView.path, func.count(PageView.id).label("count"))
+        .filter(in_range)
+        .group_by(PageView.path)
+        .order_by(func.count(PageView.id).desc())
+        .limit(TOP_N)
+        .all()
+    )
+
+    top_referrer_rows = (
+        db.query(PageView.referrer_host, func.count(PageView.id).label("count"))
+        .filter(in_range, PageView.referrer_host.isnot(None))
+        .group_by(PageView.referrer_host)
+        .order_by(func.count(PageView.id).desc())
+        .limit(TOP_N)
+        .all()
+    )
+
+    return AnalyticsSummaryDTO(
+        range_days=days,
+        total_pageviews=total_pageviews,
+        unique_visitors=unique_visitors,
+        daily_pageviews=[DailyPageViewCountDTO(day=row.day, count=row.count) for row in daily_rows],
+        top_paths=[TopPathDTO(path=row.path, count=row.count) for row in top_path_rows],
+        top_referrers=[
+            TopReferrerDTO(referrer_host=row.referrer_host, count=row.count)
+            for row in top_referrer_rows
+        ],
+    )

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -1,0 +1,65 @@
+"""Pageview ingest route — called server-side by the frontend's proxy.ts on
+every page request. Not admin-authenticated (the proxy has no admin session),
+so it is instead gated by a shared secret header and a per-IP rate limit.
+
+POST /api/analytics/pageview — record one pageview
+"""
+
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.config import ANALYTICS_INGEST_SECRET
+from app.database import get_db
+from app.models.PageView import PageView
+from app.schemas.analytics import PageViewCreateDTO
+
+router = APIRouter(prefix="/api/analytics", tags=["analytics"])
+
+RATE_LIMIT_MAX_REQUESTS = 120
+RATE_LIMIT_WINDOW = timedelta(minutes=1)
+_ingest_requests: Dict[str, List[datetime]] = {}
+
+
+def _check_rate_limit(client_ip: str) -> None:
+    now = datetime.now()
+    cutoff = now - RATE_LIMIT_WINDOW
+    recent = [ts for ts in _ingest_requests.get(client_ip, []) if ts > cutoff]
+    if len(recent) >= RATE_LIMIT_MAX_REQUESTS:
+        _ingest_requests[client_ip] = recent
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many requests")
+    recent.append(now)
+    _ingest_requests[client_ip] = recent
+
+
+def _verify_ingest_secret(x_analytics_secret: str | None = Header(default=None)) -> None:
+    if not ANALYTICS_INGEST_SECRET:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Analytics ingest is not configured",
+        )
+    if x_analytics_secret != ANALYTICS_INGEST_SECRET:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid ingest secret")
+
+
+@router.post("/pageview", status_code=status.HTTP_204_NO_CONTENT)
+def create_pageview(
+    body: PageViewCreateDTO,
+    request: Request,
+    db: Session = Depends(get_db),
+    _secret: None = Depends(_verify_ingest_secret),
+):
+    """Record one pageview. Fire-and-forget from the caller's perspective."""
+    client_ip = request.client.host if request.client else "unknown"
+    _check_rate_limit(client_ip)
+
+    view = PageView(
+        path=body.path,
+        referrer_host=body.referrer_host,
+        user_agent=body.user_agent,
+        visitor_hash=body.visitor_hash,
+    )
+    db.add(view)
+    db.commit()

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -1,0 +1,42 @@
+"""Analytics schemas — pageview ingest and admin summary DTOs."""
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PageViewCreateDTO(BaseModel):
+    path: str
+    referrer_host: str | None = None
+    user_agent: str | None = None
+    visitor_hash: str
+
+
+class DailyPageViewCountDTO(BaseModel):
+    day: date
+    count: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TopPathDTO(BaseModel):
+    path: str
+    count: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TopReferrerDTO(BaseModel):
+    referrer_host: str
+    count: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalyticsSummaryDTO(BaseModel):
+    range_days: int
+    total_pageviews: int
+    unique_visitors: int
+    daily_pageviews: list[DailyPageViewCountDTO]
+    top_paths: list[TopPathDTO]
+    top_referrers: list[TopReferrerDTO]

--- a/backend/tests/routes/test_admin_analytics.py
+++ b/backend/tests/routes/test_admin_analytics.py
@@ -1,0 +1,169 @@
+"""Integration tests for GET /api/admin/analytics/summary (issue #206)."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+from app.database import get_db
+from app.dependencies.auth import get_current_user
+from app.main import app
+from app.models import Admin
+from app.models.base import Base
+from app.models.PageView import PageView
+from app.utils.passwords import hash_password
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+def _make_engine():
+    engine = create_engine(_SQLITE_URL, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    original = {t: set(t.constraints) for t in Base.metadata.tables.values()}
+    try:
+        for t in Base.metadata.tables.values():
+            t.constraints = {c for c in t.constraints if not isinstance(c, CheckConstraint)}
+        Base.metadata.create_all(bind=engine)
+    finally:
+        for t, constraints in original.items():
+            t.constraints = constraints
+    return engine
+
+
+def _seed(engine):
+    now = datetime.now()
+    Session = sessionmaker(bind=engine)
+    db = Session()
+    db.add(
+        Admin(
+            email="admin@unc.edu",
+            first_name="Admin",
+            last_name="User",
+            onyen="user100000001",
+            password_hash=hash_password("TestPassword123!"),
+            role="admin",
+        )
+    )
+    db.add_all(
+        [
+            PageView(
+                path="/",
+                referrer_host="google.com",
+                user_agent="ua-1",
+                visitor_hash="visitor-1",
+                created_at=now - timedelta(hours=1),
+            ),
+            PageView(
+                path="/",
+                referrer_host="google.com",
+                user_agent="ua-2",
+                visitor_hash="visitor-2",
+                created_at=now - timedelta(hours=2),
+            ),
+            PageView(
+                path="/about",
+                referrer_host=None,
+                user_agent="ua-1",
+                visitor_hash="visitor-1",
+                created_at=now - timedelta(hours=3),
+            ),
+            # Outside the default 7-day window.
+            PageView(
+                path="/",
+                referrer_host="google.com",
+                user_agent="ua-3",
+                visitor_hash="visitor-3",
+                created_at=now - timedelta(days=30),
+            ),
+        ]
+    )
+    db.commit()
+    db.close()
+
+
+def _clear():
+    app.dependency_overrides.pop(get_db, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest.fixture()
+def analytics_engine():
+    engine = _make_engine()
+    _seed(engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def admin_client(analytics_engine):
+    TestSession = sessionmaker(bind=analytics_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    def _override_current_user():
+        db = TestSession()
+        user = db.query(Admin).filter(Admin.email == "admin@unc.edu").first()
+        db.close()
+        return user
+
+    app.dependency_overrides[get_db] = _override_get_db
+    app.dependency_overrides[get_current_user] = _override_current_user
+    with TestClient(app) as c:
+        yield c
+    _clear()
+
+
+class TestAnalyticsSummary:
+    def test_unauthenticated_rejected(self):
+        saved = app.dependency_overrides.pop(get_current_user, None)
+        try:
+            with TestClient(app) as c:
+                assert c.get("/api/admin/analytics/summary").status_code in {401, 403, 501}
+        finally:
+            if saved:
+                app.dependency_overrides[get_current_user] = saved
+
+    def test_returns_200(self, admin_client):
+        assert admin_client.get("/api/admin/analytics/summary").status_code == 200
+
+    def test_default_range_excludes_old_rows(self, admin_client):
+        data = admin_client.get("/api/admin/analytics/summary").json()
+        assert data["range_days"] == 7
+        assert data["total_pageviews"] == 3
+
+    def test_unique_visitors_counted_by_distinct_hash(self, admin_client):
+        data = admin_client.get("/api/admin/analytics/summary").json()
+        assert data["unique_visitors"] == 2
+
+    def test_wider_range_includes_old_row(self, admin_client):
+        data = admin_client.get("/api/admin/analytics/summary?days=90").json()
+        assert data["total_pageviews"] == 4
+
+    def test_top_paths_sorted_by_count(self, admin_client):
+        data = admin_client.get("/api/admin/analytics/summary").json()
+        assert data["top_paths"][0] == {"path": "/", "count": 2}
+
+    def test_top_referrers_excludes_null(self, admin_client):
+        data = admin_client.get("/api/admin/analytics/summary").json()
+        hosts = {row["referrer_host"] for row in data["top_referrers"]}
+        assert None not in hosts
+        assert "google.com" in hosts
+
+    def test_days_out_of_range_returns_422(self, admin_client):
+        assert admin_client.get("/api/admin/analytics/summary?days=0").status_code == 422
+        assert admin_client.get("/api/admin/analytics/summary?days=91").status_code == 422

--- a/backend/tests/routes/test_analytics.py
+++ b/backend/tests/routes/test_analytics.py
@@ -1,0 +1,125 @@
+"""Integration tests for POST /api/analytics/pageview (issue #206)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.models  # noqa: F401
+import app.routers.analytics as analytics_router
+from app.database import get_db
+from app.main import app
+from app.models.base import Base
+from app.models.PageView import PageView
+
+_SQLITE_URL = "sqlite:///:memory:"
+
+
+@pytest.fixture()
+def write_engine():
+    engine = create_engine(_SQLITE_URL, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(bind=engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def write_client(write_engine):
+    TestSession = sessionmaker(bind=write_engine)
+
+    def _override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    with TestClient(app) as c:
+        yield c, TestSession
+    app.dependency_overrides.pop(get_db, None)
+
+
+@pytest.fixture(autouse=True)
+def clear_ingest_rate_limits(monkeypatch):
+    analytics_router._ingest_requests.clear()
+    monkeypatch.setattr(analytics_router, "ANALYTICS_INGEST_SECRET", "test-ingest-secret")
+    yield
+    analytics_router._ingest_requests.clear()
+
+
+_PAYLOAD = {
+    "path": "/about",
+    "referrer_host": "google.com",
+    "user_agent": "pytest-agent",
+    "visitor_hash": "abc123",
+}
+
+
+class TestCreatePageview:
+    def test_rejects_when_not_configured(self, write_client, monkeypatch):
+        client, _ = write_client
+        monkeypatch.setattr(analytics_router, "ANALYTICS_INGEST_SECRET", None)
+        resp = client.post(
+            "/api/analytics/pageview", json=_PAYLOAD, headers={"X-Analytics-Secret": "anything"}
+        )
+        assert resp.status_code == 503
+
+    def test_rejects_missing_secret(self, write_client):
+        client, _ = write_client
+        resp = client.post("/api/analytics/pageview", json=_PAYLOAD)
+        assert resp.status_code == 401
+
+    def test_rejects_wrong_secret(self, write_client):
+        client, _ = write_client
+        resp = client.post(
+            "/api/analytics/pageview", json=_PAYLOAD, headers={"X-Analytics-Secret": "wrong"}
+        )
+        assert resp.status_code == 401
+
+    def test_accepts_correct_secret(self, write_client):
+        client, _ = write_client
+        resp = client.post(
+            "/api/analytics/pageview",
+            json=_PAYLOAD,
+            headers={"X-Analytics-Secret": "test-ingest-secret"},
+        )
+        assert resp.status_code == 204
+
+    def test_persists_pageview_row(self, write_client):
+        client, TestSession = write_client
+        client.post(
+            "/api/analytics/pageview",
+            json=_PAYLOAD,
+            headers={"X-Analytics-Secret": "test-ingest-secret"},
+        )
+        db = TestSession()
+        try:
+            rows = db.query(PageView).all()
+            assert len(rows) == 1
+            assert rows[0].path == "/about"
+            assert rows[0].referrer_host == "google.com"
+            assert rows[0].visitor_hash == "abc123"
+        finally:
+            db.close()
+
+    def test_missing_required_field_returns_422(self, write_client):
+        client, _ = write_client
+        bad = {k: v for k, v in _PAYLOAD.items() if k != "visitor_hash"}
+        resp = client.post(
+            "/api/analytics/pageview", json=bad, headers={"X-Analytics-Secret": "test-ingest-secret"}
+        )
+        assert resp.status_code == 422
+
+    def test_rate_limit_enforced(self, write_client, monkeypatch):
+        client, _ = write_client
+        monkeypatch.setattr(analytics_router, "RATE_LIMIT_MAX_REQUESTS", 2)
+
+        headers = {"X-Analytics-Secret": "test-ingest-secret"}
+        for _ in range(2):
+            resp = client.post("/api/analytics/pageview", json=_PAYLOAD, headers=headers)
+            assert resp.status_code == 204
+
+        resp = client.post("/api/analytics/pageview", json=_PAYLOAD, headers=headers)
+        assert resp.status_code == 429

--- a/deploy/cloudapps/scripts/apply-secrets.sh
+++ b/deploy/cloudapps/scripts/apply-secrets.sh
@@ -15,6 +15,7 @@ SECRET_NAME="${APP_NAME}-secrets"
 existing_db="$(get_secret_value "$SECRET_NAME" DB_PASSWORD)"
 existing_mssql="$(get_secret_value "$SECRET_NAME" MSSQL_SA_PASSWORD)"
 existing_jwt="$(get_secret_value "$SECRET_NAME" JWT_SECRET)"
+existing_analytics_secret="$(get_secret_value "$SECRET_NAME" ANALYTICS_INGEST_SECRET)"
 existing_smtp_host="$(get_secret_value "$SECRET_NAME" SMTP_HOST)"
 existing_smtp_port="$(get_secret_value "$SECRET_NAME" SMTP_PORT)"
 existing_smtp_user="$(get_secret_value "$SECRET_NAME" SMTP_USER)"
@@ -24,6 +25,7 @@ existing_smtp_from="$(get_secret_value "$SECRET_NAME" SMTP_FROM)"
 DB_PASSWORD="${DB_PASSWORD:-${existing_db:-$(generate_sql_password)}}"
 MSSQL_SA_PASSWORD="${MSSQL_SA_PASSWORD:-${existing_mssql:-$(generate_sql_password)}}"
 JWT_SECRET="${JWT_SECRET:-${existing_jwt:-$(generate_jwt_secret)}}"
+ANALYTICS_INGEST_SECRET="${ANALYTICS_INGEST_SECRET:-${existing_analytics_secret:-$(generate_jwt_secret)}}"
 SMTP_HOST="${SMTP_HOST:-${existing_smtp_host:-}}"
 SMTP_PORT="${SMTP_PORT:-${existing_smtp_port:-587}}"
 SMTP_USER="${SMTP_USER:-${existing_smtp_user:-}}"
@@ -34,6 +36,7 @@ oc create secret generic "$SECRET_NAME" \
   --from-literal=DB_PASSWORD="$DB_PASSWORD" \
   --from-literal=MSSQL_SA_PASSWORD="$MSSQL_SA_PASSWORD" \
   --from-literal=JWT_SECRET="$JWT_SECRET" \
+  --from-literal=ANALYTICS_INGEST_SECRET="$ANALYTICS_INGEST_SECRET" \
   --from-literal=SMTP_HOST="$SMTP_HOST" \
   --from-literal=SMTP_PORT="$SMTP_PORT" \
   --from-literal=SMTP_USER="$SMTP_USER" \

--- a/deploy/cloudapps/template.yaml
+++ b/deploy/cloudapps/template.yaml
@@ -334,6 +334,11 @@ objects:
                     secretKeyRef:
                       name: ${APP_NAME}-secrets
                       key: JWT_SECRET
+                - name: ANALYTICS_INGEST_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-secrets
+                      key: ANALYTICS_INGEST_SECRET
                 - name: SQLALCHEMY_ECHO
                   value: "false"
                 - name: UPLOAD_DIR
@@ -450,6 +455,11 @@ objects:
                   value: "3000"
                 - name: NEXT_PUBLIC_API_URL
                   value: ${NEXT_PUBLIC_API_URL}
+                - name: ANALYTICS_INGEST_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-secrets
+                      key: ANALYTICS_INGEST_SECRET
               resources:
                 requests:
                   memory: ${FRONTEND_MEMORY_REQUEST}

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,7 @@
 # For CloudApps, set this to the public backend route before building the frontend image.
 NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Server-only — read by proxy.ts to authenticate pageview ingest calls to the
+# backend. Must match backend's ANALYTICS_INGEST_SECRET. Never prefix this
+# with NEXT_PUBLIC_, it must not reach the browser.
+ANALYTICS_INGEST_SECRET=replace-with-a-long-random-secret

--- a/frontend/src/app/admin/analytics/page.tsx
+++ b/frontend/src/app/admin/analytics/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { AdminCard, AdminPageHeader, AdminPageShell } from "@/components/admin/AdminPageShell";
+import { AnalyticsCharts } from "@/components/admin/AnalyticsCharts";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { getAnalyticsSummary } from "@/lib/admin-api";
+import type { AnalyticsSummary } from "@/types/admin";
+import { useEffect, useState } from "react";
+
+const RANGE_OPTIONS = [
+  { label: "Last 24 hours", value: 1 },
+  { label: "Last 7 days", value: 7 },
+  { label: "Last 30 days", value: 30 },
+];
+
+export default function AdminAnalyticsPage() {
+  const [days, setDays] = useState(7);
+  const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchSummary() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await getAnalyticsSummary(days);
+        if (isMounted) setSummary(data);
+      } catch (err) {
+        console.error("Failed to fetch analytics summary:", err);
+        if (isMounted) setError("Failed to load analytics data.");
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    }
+
+    fetchSummary();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [days]);
+
+  return (
+    <AdminPageShell>
+      <AdminPageHeader
+        title="Analytics"
+        description="Server-side pageview stats collected via the site's proxy — no third-party scripts, cookies, or PII."
+        action={
+          <Select
+            value={String(days)}
+            onValueChange={(value) => setDays(Number(value))}
+          >
+            <SelectTrigger className="w-44">
+              <SelectValue placeholder="Select range" />
+            </SelectTrigger>
+            <SelectContent>
+              {RANGE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={String(option.value)}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        }
+      />
+
+      <AdminCard>
+        {isLoading ? (
+          <div className="py-20 text-center text-slate-500">Loading data...</div>
+        ) : error ? (
+          <div className="py-20 text-center text-rose-600">{error}</div>
+        ) : summary ? (
+          <AnalyticsCharts summary={summary} />
+        ) : null}
+      </AdminCard>
+    </AdminPageShell>
+  );
+}

--- a/frontend/src/components/admin/AnalyticsCharts.tsx
+++ b/frontend/src/components/admin/AnalyticsCharts.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import type { AnalyticsSummary } from "@/types/admin";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+function StatTile({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        {label}
+      </p>
+      <p className="mt-1 text-2xl font-semibold text-slate-900">
+        {value.toLocaleString()}
+      </p>
+    </div>
+  );
+}
+
+function TopList({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: { label: string; count: number }[];
+}) {
+  return (
+    <div>
+      <h3 className="mb-2 text-sm font-semibold text-slate-700">{title}</h3>
+      {rows.length === 0 ? (
+        <p className="py-6 text-center text-sm text-slate-500">No data yet.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-slate-200">
+          <table className="w-full min-w-max text-left text-sm">
+            <thead className="border-b border-slate-200 bg-slate-50">
+              <tr>
+                <th className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  {title}
+                </th>
+                <th className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Views
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {rows.map((row) => (
+                <tr key={row.label} className="hover:bg-slate-50/70">
+                  <td className="px-4 py-2 text-slate-700">{row.label}</td>
+                  <td className="px-4 py-2 text-slate-700">{row.count.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AnalyticsCharts({ summary }: { summary: AnalyticsSummary }) {
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <StatTile label="Pageviews" value={summary.total_pageviews} />
+        <StatTile label="Unique Visitors" value={summary.unique_visitors} />
+      </div>
+
+      <div>
+        <h3 className="mb-2 text-sm font-semibold text-slate-700">
+          Pageviews over time
+        </h3>
+        <div className="h-72 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={summary.daily_pageviews}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+              <XAxis dataKey="day" tick={{ fontSize: 12, fill: "#64748b" }} />
+              <YAxis allowDecimals={false} tick={{ fontSize: 12, fill: "#64748b" }} />
+              <Tooltip />
+              <Line
+                type="monotone"
+                dataKey="count"
+                name="Pageviews"
+                stroke="#2563eb"
+                strokeWidth={2}
+                dot={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <TopList
+          title="Top Pages"
+          rows={summary.top_paths.map((row) => ({ label: row.path, count: row.count }))}
+        />
+        <TopList
+          title="Top Referrers"
+          rows={summary.top_referrers.map((row) => ({
+            label: row.referrer_host,
+            count: row.count,
+          }))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/Sidebar.tsx
+++ b/frontend/src/components/admin/Sidebar.tsx
@@ -26,6 +26,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: "Budget", href: "/admin/budget" },
   { label: "Static Pages", href: "/admin/static-pages" },
   { label: "Districts", href: "/admin/districts" },
+  { label: "Analytics", href: "/admin/analytics" },
   { label: "Accounts", href: "/admin/accounts", adminOnly: true },
 ];
 

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -18,6 +18,7 @@ import type {
   AdminLeadership,
   AdminNews,
   AdminStaff,
+  AnalyticsSummary,
   AssignCommitteeMember,
   CreateAccount,
   CreateBudgetData,
@@ -533,6 +534,13 @@ export async function updateStaff(
 
 export async function deleteStaff(id: number): Promise<void> {
   return request<void>(`/admin/staff/${id}`, { method: "DELETE" });
+}
+
+// Analytics
+export async function getAnalyticsSummary(
+  days: number = 7,
+): Promise<AnalyticsSummary> {
+  return request(`/admin/analytics/summary?days=${days}`, { method: "GET" });
 }
 
 // Budget

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,0 +1,59 @@
+import crypto from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+const INGEST_SECRET = process.env.ANALYTICS_INGEST_SECRET;
+const API_BASE = (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000").replace(
+  /\/+$/,
+  "",
+);
+
+function hashVisitor(ip: string, userAgent: string): string {
+  const today = new Date().toISOString().slice(0, 10);
+  return crypto
+    .createHash("sha256")
+    .update(`${ip}:${userAgent}:${today}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function refererHost(refererHeader: string | null): string | null {
+  if (!refererHeader) return null;
+  try {
+    return new URL(refererHeader).hostname;
+  } catch {
+    return null;
+  }
+}
+
+export function proxy(request: NextRequest) {
+  const isPrefetch =
+    request.headers.get("next-router-prefetch") === "1" ||
+    request.headers.get("purpose") === "prefetch";
+
+  if (INGEST_SECRET && !isPrefetch) {
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const userAgent = request.headers.get("user-agent") ?? "unknown";
+
+    fetch(`${API_BASE}/api/analytics/pageview`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Analytics-Secret": INGEST_SECRET,
+      },
+      body: JSON.stringify({
+        path: request.nextUrl.pathname,
+        referrer_host: refererHost(request.headers.get("referer")),
+        user_agent: userAgent,
+        visitor_hash: hashVisitor(ip, userAgent),
+      }),
+    }).catch(() => {
+      // Best-effort only — a failed analytics call must never block the page.
+    });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!admin|api|_next/static|_next/image|favicon.ico).*)"],
+};

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -264,3 +264,27 @@ export interface AdminLeadership {
   session_number: number;
   is_current: boolean;
 }
+
+export interface DailyPageViewCount {
+  day: string;
+  count: number;
+}
+
+export interface TopPath {
+  path: string;
+  count: number;
+}
+
+export interface TopReferrer {
+  referrer_host: string;
+  count: number;
+}
+
+export interface AnalyticsSummary {
+  range_days: number;
+  total_pageviews: number;
+  unique_visitors: number;
+  daily_pageviews: DailyPageViewCount[];
+  top_paths: TopPath[];
+  top_referrers: TopReferrer[];
+}


### PR DESCRIPTION
We wanted lightweight, self-hosted pageview analytics for the site — similar in spirit to Google Analytics, but without embedding a third-party script or cookie on the live pages users see. GA was ruled out because it ships visitor data off our infra and requires cookie consent, which is disproportionate for a UNC-affiliated public site. Instead, pageviews are captured server-side and surfaced only in a new admin-only tab — nothing changes about what a visitor's browser loads.

Changes:

- Added a Next.js `proxy.ts` request interceptor that fires a non-blocking POST per real pageview (prefetches filtered out), because that's the only way to observe traffic without adding a client-side script
- Added a `PageView` table plus `POST /api/analytics/pageview` for ingest, protected by a shared secret header and a per-IP rate limit, since the proxy has no admin session to authenticate with
- Added `GET /api/admin/analytics/summary` (daily pageviews, unique visitors, top pages, top referrers), gated by the existing `get_current_user` admin auth like every other admin route
- Added an "Analytics" tab to the admin dashboard (Recharts line chart + stat tiles + top-pages/referrers tables) so the data is actually visible somewhere
- `visitor_hash` is a daily-rotating, non-reversible hash of IP + user agent — no raw IP is stored and no cookie is set, since unique-visitor counting shouldn't require either
- Built as `proxy.ts` rather than `middleware.ts` — Next.js 16 renamed the convention and made Node.js the only, non-configurable runtime for it, which the original issue plan hadn't accounted for
- Wired a new `ANALYTICS_INGEST_SECRET` into `deploy/cloudapps/scripts/apply-secrets.sh` and `template.yaml` (same `secretKeyRef` pattern as `JWT_SECRET`), because adding the env var to the app alone doesn't reach the running OpenShift pods

**Deployment — action needed after merge:** run `./deploy/cloudapps/scripts/apply-environment.sh senate` once (requires `oc` access) so the new secret gets generated and injected into both Deployments. Safe to merge without doing this right away — if the secret isn't present yet, the backend ingest route returns 503 and the frontend proxy just skips sending events, so nothing breaks in the meantime.

Verified: 588/588 backend tests pass (15 new), ruff clean, tsc clean, vitest passes, `next build` succeeds.

Closes #206