### PR TITLE
Fix slow page loads: parallelize homepage fetches, restore caching, fix senators N+1

### DIFF
--- a/backend/app/models/Senator.py
+++ b/backend/app/models/Senator.py
@@ -1,13 +1,16 @@
 """Senator model."""
 
 from datetime import datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from sqlalchemy import CHAR, Boolean, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
 from .base import Base
+
+if TYPE_CHECKING:
+    from .cms import CommitteeMembership
 
 
 class Senator(Base):
@@ -29,7 +32,7 @@ class Senator(Base):
     )
 
     # Relationships (referenced by cms.py)
-    committee_memberships: Mapped[list] = relationship(
+    committee_memberships: Mapped[list["CommitteeMembership"]] = relationship(
         "CommitteeMembership", back_populates="senator"
     )
 

--- a/backend/app/routers/senators.py
+++ b/backend/app/routers/senators.py
@@ -11,10 +11,10 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, or_, true
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.database import get_db
-from app.models.cms import Committee, CommitteeMembership
+from app.models.cms import CommitteeMembership
 from app.models.Senator import Senator
 
 try:
@@ -28,33 +28,24 @@ except ImportError:  # pragma: no cover — removed once PR #37 merges
 router = APIRouter(prefix="/api/senators", tags=["senators"])
 
 
-def _senator_to_dict(senator: Senator, db: Session) -> dict[str, Any]:
+def _senator_to_dict(senator: Senator) -> dict[str, Any]:
     """Convert a Senator ORM row to a dict compatible with PR #37's SenatorDTO.
 
     Key remappings vs the model:
     - ``district``  (model column)  → ``district_id``  (DTO field in PR #37)
     - ``committee_memberships``  (relationship)  → ``committees``  (DTO field in PR #37)
 
-    Memberships are queried explicitly to avoid SQLAlchemy inference issues with
-    the untyped ``Mapped[list]`` annotation on ``Senator.committee_memberships``.
+    Relies on ``_base_query``'s ``selectinload`` to have eagerly loaded
+    ``committee_memberships`` (and each membership's ``committee``), so this
+    reads only already-fetched data instead of issuing per-senator queries.
     """
-    memberships = (
-        db.query(CommitteeMembership).filter(CommitteeMembership.senator_id == senator.id).all()
-    )
-    committee_ids = [m.committee_id for m in memberships]
-    committees_by_id = (
-        {c.id: c.name for c in db.query(Committee).filter(Committee.id.in_(committee_ids)).all()}
-        if committee_ids
-        else {}
-    )
-
     committees = [
         {
             "committee_id": m.committee_id,
-            "committee_name": committees_by_id.get(m.committee_id, ""),
+            "committee_name": m.committee.name if m.committee else "",
             "role": m.role,
         }
-        for m in memberships
+        for m in senator.committee_memberships
     ]
     return {
         "id": senator.id,
@@ -70,8 +61,10 @@ def _senator_to_dict(senator: Senator, db: Session) -> dict[str, Any]:
 
 
 def _base_query(db: Session):
-    """Base query for senators."""
-    return db.query(Senator)
+    """Base query for senators, with committee memberships eagerly loaded."""
+    return db.query(Senator).options(
+        selectinload(Senator.committee_memberships).selectinload(CommitteeMembership.committee)
+    )
 
 
 def _current_session(db: Session) -> int:
@@ -120,7 +113,7 @@ def list_senators(
         ).filter(CommitteeMembership.committee_id == committee)
 
     senators_orm = query.all()
-    dicts: list[Any] = [_senator_to_dict(s, db) for s in senators_orm]
+    dicts: list[Any] = [_senator_to_dict(s) for s in senators_orm]
 
     if _SENATOR_DTO_AVAILABLE:
         from app.schemas.senator import SenatorDTO
@@ -136,7 +129,7 @@ def get_senator(senator_id: int, db: Session = Depends(get_db)):
     if senator is None:
         raise HTTPException(status_code=404, detail="Senator not found")
 
-    data = _senator_to_dict(senator, db)
+    data = _senator_to_dict(senator)
     if _SENATOR_DTO_AVAILABLE:
         from app.schemas.senator import SenatorDTO
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,39 +5,46 @@ import FinanceHearingButton from "@/components/home/FinanceHearingButton";
 import RecentNews from "@/components/home/RecentNews";
 import EmptyState from "@/components/ui/EmptyState";
 import ErrorMessage from "@/components/ui/ErrorMessage";
-import { ApiError, getCarousel, getEvents, getFinanceHearings } from "@/lib/api";
+import {
+  ApiError,
+  getCarousel,
+  getEvents,
+  getFinanceHearings,
+  getNews,
+} from "@/lib/api";
 import { financeHearingsToCalendarEvents } from "@/lib/calendar";
 
 export default async function Home() {
-  let slides: Awaited<ReturnType<typeof getCarousel>> = [];
-  let events: Awaited<ReturnType<typeof getEvents>> = [];
+  const [slidesResult, eventsResult, financeHearingsResult, newsResult] =
+    await Promise.allSettled([
+      getCarousel(),
+      getEvents(),
+      getFinanceHearings(),
+      getNews(1, 3),
+    ]);
+
+  const slides = slidesResult.status === "fulfilled" ? slidesResult.value : [];
+  const carouselError = slidesResult.status === "rejected";
+
+  const events = eventsResult.status === "fulfilled" ? eventsResult.value : [];
+  const eventsError = eventsResult.status === "rejected";
+
   let financeHearings: Awaited<ReturnType<typeof getFinanceHearings>> | null =
     null;
-  let carouselError = false;
-  let eventsError = false;
   let financeError = false;
-
-  try {
-    slides = await getCarousel();
-  } catch {
-    carouselError = true;
-  }
-
-  try {
-    events = await getEvents();
-  } catch {
-    eventsError = true;
-  }
-
-  try {
-    financeHearings = await getFinanceHearings();
-  } catch (err) {
+  if (financeHearingsResult.status === "fulfilled") {
+    financeHearings = financeHearingsResult.value;
+  } else {
+    const err = financeHearingsResult.reason;
     if (err instanceof ApiError && err.status === 404) {
       // no config row exists yet — valid empty state
     } else {
       financeError = true;
     }
   }
+
+  const newsData = newsResult.status === "fulfilled" ? newsResult.value : null;
+  const newsError = newsResult.status === "rejected";
 
   const calendarEvents = [
     ...events,
@@ -66,7 +73,7 @@ export default async function Home() {
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-12">
           <div className="lg:col-span-2">
-            <RecentNews />
+            <RecentNews newsData={newsData} error={newsError} />
           </div>
           <div>
             {eventsError ? (

--- a/frontend/src/components/home/RecentNews.tsx
+++ b/frontend/src/components/home/RecentNews.tsx
@@ -1,16 +1,18 @@
 import { Card } from "@/components/ui/card";
-import { getNews } from "@/lib/api";
 import { IMAGE_PATHS } from "@/lib/imagePaths";
 import type { News } from "@/types";
+import type { PaginatedResponse } from "@/types/api";
 import { format } from "date-fns";
 import Image from "next/image";
 import Link from "next/link";
 
-export default async function RecentNews() {
-  let newsData;
-  try {
-    newsData = await getNews(1, 3);
-  } catch {
+interface RecentNewsProps {
+  newsData: PaginatedResponse<News> | null;
+  error: boolean;
+}
+
+export default function RecentNews({ newsData, error }: RecentNewsProps) {
+  if (error || !newsData) {
     return (
       <div className="recent-news">
         <h2 className="text-2xl font-bold mb-4">Recent News</h2>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -112,12 +112,18 @@ async function extractErrorDetails(response: Response): Promise<unknown> {
 export async function fetchAPI<T>(
   endpoint: string,
   options?: RequestInit,
+  revalidateSeconds?: number,
 ): Promise<T> {
   const url = `${API_BASE_URL}${normalizeEndpoint(endpoint)}`;
 
+  const cacheOptions: RequestInit =
+    revalidateSeconds !== undefined
+      ? { next: { revalidate: revalidateSeconds } }
+      : { cache: "no-store" };
+
   let response: Response;
   try {
-    response = await fetch(url, { cache: "no-store", ...options });
+    response = await fetch(url, { ...cacheOptions, ...options });
   } catch (error) {
     throw new ApiError(0, "Network request failed", error);
   }
@@ -173,17 +179,17 @@ export async function getSenatorById(id: string | number): Promise<Senator> {
 }
 
 export async function getLeadership(session?: number): Promise<Leadership[]> {
-  return fetchAPI<Leadership[]>(buildLeadershipEndpoint(session));
+  return fetchAPI<Leadership[]>(buildLeadershipEndpoint(session), undefined, 60);
 }
 
 export async function getCommittees(): Promise<Committee[]> {
-  return fetchAPI<Committee[]>("/api/committees/");
+  return fetchAPI<Committee[]>("/api/committees/", undefined, 60);
 }
 
 export async function getCommitteeById(
   id: string | number,
 ): Promise<Committee> {
-  return fetchAPI<Committee>(`/api/committees/${id}`);
+  return fetchAPI<Committee>(`/api/committees/${id}`, undefined, 60);
 }
 
 export async function getLegislation(
@@ -231,11 +237,11 @@ export async function getCarousel(): Promise<CarouselSlide[]> {
 }
 
 export async function getFinanceHearings(): Promise<FinanceHearingConfig> {
-  return fetchAPI<FinanceHearingConfig>("/api/finance-hearings");
+  return fetchAPI<FinanceHearingConfig>("/api/finance-hearings", undefined, 60);
 }
 
 export async function getStaff(): Promise<Staff[]> {
-  return fetchAPI<Staff[]>("/api/staff");
+  return fetchAPI<Staff[]>("/api/staff", undefined, 60);
 }
 
 export async function getDistricts(): Promise<District[]> {


### PR DESCRIPTION
Users reported the site sometimes takes a while to load. Investigation (issue #205) found three separate, compounding causes — a sequential fetch waterfall on the homepage, caching disabled on several admin-editable pages, and an N+1 query pattern on the senators API.

Changes:

- `frontend/src/app/page.tsx`, `RecentNews.tsx` — the homepage awaited `getCarousel()`, `getEvents()`, `getFinanceHearings()`, and (via the nested `RecentNews` server component) `getNews()` sequentially, meaning every visit stacked 4 backend round trips in series. Switched to `Promise.allSettled` so they run concurrently, and turned `RecentNews` into a plain presentational component that receives its data as a prop instead of fetching on its own.
- `frontend/src/lib/api.ts` — `fetchAPI` hardcoded `cache: "no-store"`, so admin-editable pages (staff, leadership, committees, finance hearings) re-fetched from the backend on every single request with zero caching. Added an optional `revalidateSeconds` param and switched `getStaff`, `getLeadership`, `getCommittees`, `getCommitteeById`, and `getFinanceHearings` to a 60s revalidate window — admin edits still show up within a minute, but requests in between are served from cache instead of hitting the backend live.
- `backend/app/routers/senators.py`, `models/Senator.py` — `list_senators` issued 2 extra DB queries per senator (`2N + 1` total) instead of eager-loading committee memberships, unlike `committees.py`'s equivalent endpoint which already uses `selectinload` correctly. Fixed by eager-loading via `selectinload` in `_base_query`. This also surfaced a real bug in the model: `Senator.committee_memberships` was typed as bare `Mapped[list]` (no type param), which made SQLAlchemy infer `uselist=False` and silently return a single row or `None` instead of a list — exactly the landmine the old code's docstring said it was working around by hand-querying instead of using the relationship. Fixed the annotation to `Mapped[list["CommitteeMembership"]]`.

Verified: all 588 backend tests pass, `tsc --noEmit` is clean, and `next build` confirms `/about/staff`, `/committees`, `/funding/apply`, `/senators/leadership` flipped from fully dynamic (`ƒ`) to ISR (`○`, 1m revalidate).

Closes #205