### PR TITLE
Make email optional on Leadership records

### DIFF
--- a/backend/app/models/Leadership.py
+++ b/backend/app/models/Leadership.py
@@ -20,7 +20,7 @@ class Leadership(Base):
     title: Mapped[str] = mapped_column(String(200), nullable=False)
     first_name: Mapped[str] = mapped_column(String(100), nullable=False)
     last_name: Mapped[str] = mapped_column(String(100), nullable=False)
-    email: Mapped[str] = mapped_column(String(255), nullable=False)
+    email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     headshot_url: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     session_number: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/app/schemas/leadership.py
+++ b/backend/app/schemas/leadership.py
@@ -9,7 +9,7 @@ class LeadershipDTO(BaseModel):
     title: str
     first_name: str
     last_name: str
-    email: str
+    email: str | None
     photo_url: str | None
     session_number: int
     is_current: bool
@@ -22,7 +22,7 @@ class CreateLeadershipDTO(BaseModel):
     title: str
     first_name: str
     last_name: str
-    email: EmailStr
+    email: EmailStr | None = None
     headshot_url: str | None = None
     is_active: bool = True
     session_number: int

--- a/backend/tests/routers/test_admin_leadership.py
+++ b/backend/tests/routers/test_admin_leadership.py
@@ -68,6 +68,23 @@ def test_create_admin_leadership(admin_client):
     assert data["session_number"] == 2026
 
 
+def test_create_admin_leadership_without_email(admin_client):
+    response = admin_client.post(
+        "/api/admin/leadership",
+        json={
+            "title": "Secretary",
+            "first_name": "Taylor",
+            "last_name": "Green",
+            "session_number": 2026,
+            "is_active": True,
+        },
+    )
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["email"] is None
+
+
 def test_create_admin_leadership_invalid_senator_returns_404(admin_client):
     response = admin_client.post(
         "/api/admin/leadership",

--- a/frontend/src/app/senators/leadership/page.tsx
+++ b/frontend/src/app/senators/leadership/page.tsx
@@ -51,12 +51,14 @@ export default async function LeadershipPage() {
                   <h3 className="text-lg font-semibold text-gray-900 mb-2">
                     {leader.first_name} {leader.last_name}
                   </h3>
-                  <a
-                    href={`mailto:${leader.email}`}
-                    className="text-blue-600 hover:text-blue-800 text-sm"
-                  >
-                    {leader.email}
-                  </a>
+                  {leader.email && (
+                    <a
+                      href={`mailto:${leader.email}`}
+                      className="text-blue-600 hover:text-blue-800 text-sm"
+                    >
+                      {leader.email}
+                    </a>
+                  )}
                 </CardContent>
               </Card>
             ))}

--- a/frontend/src/components/admin/LeadershipForm.tsx
+++ b/frontend/src/components/admin/LeadershipForm.tsx
@@ -67,7 +67,7 @@ export function LeadershipForm({
       title,
       first_name: firstName,
       last_name: lastName,
-      email,
+      email: email || null,
       session_number: parseInt(sessionNumber),
       is_active: isActive,
       senator_id: senatorId,
@@ -132,10 +132,9 @@ export function LeadershipForm({
         {/* Email Field */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Email <span className="text-red-500">*</span>
+            Email
           </label>
           <input
-            required
             type="email"
             className="w-full p-2 border rounded border-gray-300"
             value={email}

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -236,7 +236,7 @@ export interface CreateLeadership {
   title: string;
   first_name: string;
   last_name: string;
-  email: string;
+  email: string | null;
   headshot_url?: string | null;
   is_active?: boolean;
   session_number: number;
@@ -247,7 +247,7 @@ export interface UpdateLeadership {
   title?: string;
   first_name?: string;
   last_name?: string;
-  email?: string;
+  email?: string | null;
   headshot_url?: string | null;
   is_active?: boolean;
   session_number?: number;
@@ -259,7 +259,7 @@ export interface AdminLeadership {
   title: string;
   first_name: string;
   last_name: string;
-  email: string;
+  email: string | null;
   photo_url: string | null;
   session_number: number;
   is_current: boolean;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,7 +40,7 @@ export interface Leadership {
   title: string;
   first_name: string;
   last_name: string;
-  email: string;
+  email: string | null;
   photo_url: string | null;
   session_number: number;
   is_current: boolean;


### PR DESCRIPTION
Previous leadership records often don't have a known or current email address, but the leadership table's email column was required end-to-end (DB column, create schema, and admin form), which blocked uploading that historical data.

Changes:

- Made `email` nullable on the `Leadership` model (was `nullable=False`)
- Updated `LeadershipDTO`/`CreateLeadershipDTO` to allow `None` for email (`UpdateLeadershipDTO` already allowed it)
- Removed the `required` attribute and asterisk from the email field in the admin Leadership form, and send `null` instead of an empty string when left blank
- Updated `Leadership`/`CreateLeadership`/`AdminLeadership` frontend types to allow `null` email
- Guarded the `mailto:` link on the public leadership page so it only renders when an email is present
- Added a test covering leadership creation without an email

Note: existing deployed databases will need a manual `ALTER TABLE leadership ALTER COLUMN email DROP NOT NULL` since there's no migration tooling in this repo — the schema is created via `metadata.create_all()`.

Closes #207