### PR TITLE
Add live users, custom tooltip, hourly 24h view; drop admin tab descriptions

### DIFF
--- a/backend/app/routers/admin/analytics.py
+++ b/backend/app/routers/admin/analytics.py
@@ -1,6 +1,7 @@
 """Admin analytics routes.
 
 GET /api/admin/analytics/summary — aggregated pageview stats for the dashboard
+GET /api/admin/analytics/active — count of visitors active in the trailing window
 """
 
 from datetime import datetime, timedelta
@@ -14,6 +15,7 @@ from app.dependencies.auth import get_current_user
 from app.models.Admin import Admin
 from app.models.PageView import PageView
 from app.schemas.analytics import (
+    ActiveUsersDTO,
     AnalyticsSummaryDTO,
     DailyPageViewCountDTO,
     TopPathDTO,
@@ -23,6 +25,7 @@ from app.schemas.analytics import (
 router = APIRouter(prefix="/api/admin/analytics", tags=["admin", "analytics"])
 
 TOP_N = 10
+ACTIVE_WINDOW_MINUTES = 5
 
 
 @router.get("/summary", response_model=AnalyticsSummaryDTO)
@@ -40,12 +43,18 @@ def get_analytics_summary(
         db.query(PageView.visitor_hash).filter(in_range).distinct().count()
     )
 
-    day_col = func.date(PageView.created_at).label("day")
+    # A 1-day range is bucketed by hour (daily buckets would collapse to one point).
+    # Buckets are computed in the database's session timezone (UTC in production).
+    bucket_col = (
+        func.date_trunc("hour", PageView.created_at).label("day")
+        if days <= 1
+        else func.date(PageView.created_at).label("day")
+    )
     daily_rows = (
-        db.query(day_col, func.count(PageView.id).label("count"))
+        db.query(bucket_col, func.count(PageView.id).label("count"))
         .filter(in_range)
-        .group_by(day_col)
-        .order_by(day_col)
+        .group_by(bucket_col)
+        .order_by(bucket_col)
         .all()
     )
 
@@ -78,3 +87,19 @@ def get_analytics_summary(
             for row in top_referrer_rows
         ],
     )
+
+
+@router.get("/active", response_model=ActiveUsersDTO)
+def get_active_users(
+    _current_user: Admin = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Count distinct visitors seen in the trailing ACTIVE_WINDOW_MINUTES minutes."""
+    cutoff = datetime.now() - timedelta(minutes=ACTIVE_WINDOW_MINUTES)
+    active_users = (
+        db.query(PageView.visitor_hash)
+        .filter(PageView.created_at >= cutoff)
+        .distinct()
+        .count()
+    )
+    return ActiveUsersDTO(active_users=active_users)

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -1,6 +1,6 @@
 """Analytics schemas — pageview ingest and admin summary DTOs."""
 
-from datetime import date
+from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
@@ -13,10 +13,14 @@ class PageViewCreateDTO(BaseModel):
 
 
 class DailyPageViewCountDTO(BaseModel):
-    day: date
+    day: datetime
     count: int
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ActiveUsersDTO(BaseModel):
+    active_users: int
 
 
 class TopPathDTO(BaseModel):

--- a/frontend/src/app/admin/analytics/page.tsx
+++ b/frontend/src/app/admin/analytics/page.tsx
@@ -9,7 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { getAnalyticsSummary } from "@/lib/admin-api";
+import { getActiveUsers, getAnalyticsSummary } from "@/lib/admin-api";
 import type { AnalyticsSummary } from "@/types/admin";
 import { useEffect, useState } from "react";
 
@@ -19,11 +19,14 @@ const RANGE_OPTIONS = [
   { label: "Last 30 days", value: 30 },
 ];
 
+const ACTIVE_USERS_POLL_MS = 30_000;
+
 export default function AdminAnalyticsPage() {
   const [days, setDays] = useState(7);
   const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [activeUsers, setActiveUsers] = useState<number | null>(null);
 
   useEffect(() => {
     let isMounted = true;
@@ -49,11 +52,31 @@ export default function AdminAnalyticsPage() {
     };
   }, [days]);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    async function fetchActiveUsers() {
+      try {
+        const data = await getActiveUsers();
+        if (isMounted) setActiveUsers(data.active_users);
+      } catch (err) {
+        console.error("Failed to fetch active users:", err);
+      }
+    }
+
+    fetchActiveUsers();
+    const interval = setInterval(fetchActiveUsers, ACTIVE_USERS_POLL_MS);
+
+    return () => {
+      isMounted = false;
+      clearInterval(interval);
+    };
+  }, []);
+
   return (
     <AdminPageShell>
       <AdminPageHeader
         title="Analytics"
-        description="Server-side pageview stats collected via the site's proxy — no third-party scripts, cookies, or PII."
         action={
           <Select
             value={String(days)}
@@ -79,7 +102,7 @@ export default function AdminAnalyticsPage() {
         ) : error ? (
           <div className="py-20 text-center text-rose-600">{error}</div>
         ) : summary ? (
-          <AnalyticsCharts summary={summary} />
+          <AnalyticsCharts summary={summary} activeUsers={activeUsers} />
         ) : null}
       </AdminCard>
     </AdminPageShell>

--- a/frontend/src/app/admin/budget/page.tsx
+++ b/frontend/src/app/admin/budget/page.tsx
@@ -311,7 +311,6 @@ export default function AdminBudgetPage() {
     <AdminPageShell className="space-y-8">
       <AdminPageHeader
         title="Budget"
-        description="Manage fiscal-year categories for the budget visualization."
       />
 
       {error ? (

--- a/frontend/src/app/admin/finance-hearings/page.tsx
+++ b/frontend/src/app/admin/finance-hearings/page.tsx
@@ -201,7 +201,6 @@ export default function AdminFinanceHearingsPage() {
     <AdminPageShell className="space-y-8">
       <AdminPageHeader
         title="Finance Hearings"
-        description="Manage hearing season availability and date slots."
       />
 
       {error ? (

--- a/frontend/src/app/admin/legislation/[id]/page.tsx
+++ b/frontend/src/app/admin/legislation/[id]/page.tsx
@@ -147,7 +147,6 @@ export default function LegislationDetailsPage() {
 
       <AdminPageHeader
         title={`${legislation.bill_number}: ${legislation.title}`}
-        description="Review the legislation metadata and manage timeline actions."
       />
 
       <AdminCard>

--- a/frontend/src/app/admin/legislation/page.tsx
+++ b/frontend/src/app/admin/legislation/page.tsx
@@ -155,7 +155,6 @@ export default function AdminLegislationPage() {
     <AdminPageShell>
       <AdminPageHeader
         title="Legislation Management"
-        description="Create, edit, and maintain legislation records and metadata."
         action={
           <Button
             type="button"

--- a/frontend/src/app/admin/senators/page.tsx
+++ b/frontend/src/app/admin/senators/page.tsx
@@ -272,7 +272,6 @@ export default function AdminSenatorsPage() {
     <AdminPageShell>
       <AdminPageHeader
         title="Senators Management"
-        description="Manage the active roster, session assignments, and contact details."
         action={
           <Button
             type="button"

--- a/frontend/src/app/admin/static-pages/page.tsx
+++ b/frontend/src/app/admin/static-pages/page.tsx
@@ -118,7 +118,6 @@ export default function AdminStaticPagesPage() {
     <AdminPageShell>
       <AdminPageHeader
         title="Static Pages"
-        description="These pages are pre-configured. You can edit content but cannot add or remove pages."
       />
 
       <AdminCard>

--- a/frontend/src/components/admin/AnalyticsCharts.tsx
+++ b/frontend/src/components/admin/AnalyticsCharts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { AnalyticsSummary } from "@/types/admin";
+import type { AnalyticsSummary, DailyPageViewCount } from "@/types/admin";
 import {
   CartesianGrid,
   Line,
@@ -11,14 +11,14 @@ import {
   YAxis,
 } from "recharts";
 
-function StatTile({ label, value }: { label: string; value: number }) {
+function StatTile({ label, value }: { label: string; value: number | null }) {
   return (
     <div className="rounded-lg border border-slate-200 bg-white p-4">
       <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
         {label}
       </p>
       <p className="mt-1 text-2xl font-semibold text-slate-900">
-        {value.toLocaleString()}
+        {value === null ? "—" : value.toLocaleString()}
       </p>
     </div>
   );
@@ -64,25 +64,85 @@ function TopList({
   );
 }
 
-export function AnalyticsCharts({ summary }: { summary: AnalyticsSummary }) {
+// Bucket timestamps are UTC (the database's session timezone); format in UTC
+// so the axis/tooltip stay consistent with how buckets were computed.
+function formatBucketLabel(value: string, hourly: boolean): string {
+  const date = new Date(value);
+  return hourly
+    ? date.toLocaleTimeString("en-US", { hour: "numeric", timeZone: "UTC" })
+    : date.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}
+
+function AnalyticsTooltip({
+  active,
+  payload,
+  hourly,
+  data,
+}: {
+  active?: boolean;
+  payload?: { payload: DailyPageViewCount }[];
+  hourly: boolean;
+  data: DailyPageViewCount[];
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const row = payload[0].payload;
+  const index = data.findIndex((d) => d.day === row.day);
+  const previous = index > 0 ? data[index - 1] : null;
+  const change =
+    previous && previous.count > 0
+      ? ((row.count - previous.count) / previous.count) * 100
+      : null;
+
+  return (
+    <div className="rounded-md border border-slate-200 bg-white px-3 py-2 text-xs shadow-md">
+      <p className="font-semibold text-slate-700">{formatBucketLabel(row.day, hourly)}</p>
+      <p className="mt-1 text-slate-600">
+        {row.count.toLocaleString()} pageview{row.count === 1 ? "" : "s"}
+      </p>
+      {change !== null && (
+        <p className={change >= 0 ? "mt-0.5 text-emerald-600" : "mt-0.5 text-rose-600"}>
+          {change >= 0 ? "+" : ""}
+          {change.toFixed(1)}% vs. previous {hourly ? "hour" : "day"}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function AnalyticsCharts({
+  summary,
+  activeUsers,
+}: {
+  summary: AnalyticsSummary;
+  activeUsers: number | null;
+}) {
+  const hourly = summary.range_days <= 1;
+
   return (
     <div className="space-y-6">
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <StatTile label="Pageviews" value={summary.total_pageviews} />
         <StatTile label="Unique Visitors" value={summary.unique_visitors} />
+        <StatTile label="Active Now" value={activeUsers} />
       </div>
 
       <div>
         <h3 className="mb-2 text-sm font-semibold text-slate-700">
           Pageviews over time
+          {hourly && <span className="ml-2 text-xs font-normal text-slate-400">(times in UTC)</span>}
         </h3>
         <div className="h-72 w-full">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={summary.daily_pageviews}>
               <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
-              <XAxis dataKey="day" tick={{ fontSize: 12, fill: "#64748b" }} />
+              <XAxis
+                dataKey="day"
+                tickFormatter={(value: string) => formatBucketLabel(value, hourly)}
+                tick={{ fontSize: 12, fill: "#64748b" }}
+              />
               <YAxis allowDecimals={false} tick={{ fontSize: 12, fill: "#64748b" }} />
-              <Tooltip />
+              <Tooltip content={<AnalyticsTooltip hourly={hourly} data={summary.daily_pageviews} />} />
               <Line
                 type="monotone"
                 dataKey="count"

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -14,6 +14,7 @@ import type {
 } from "@/types";
 import type {
   Account,
+  ActiveUsers,
   AdminDistrict,
   AdminLeadership,
   AdminNews,
@@ -541,6 +542,10 @@ export async function getAnalyticsSummary(
   days: number = 7,
 ): Promise<AnalyticsSummary> {
   return request(`/admin/analytics/summary?days=${days}`, { method: "GET" });
+}
+
+export async function getActiveUsers(): Promise<ActiveUsers> {
+  return request(`/admin/analytics/active`, { method: "GET" });
 }
 
 // Budget

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -288,3 +288,7 @@ export interface AnalyticsSummary {
   top_paths: TopPath[];
   top_referrers: TopReferrer[];
 }
+
+export interface ActiveUsers {
+  active_users: number;
+}


### PR DESCRIPTION
Adds a few small improvements to the admin Analytics tab and cleans up admin page headers.

Changes:

- Added a live/current-users stat (`GET /api/admin/analytics/active`, distinct visitor_hash in the trailing 5 minutes), polled every 30s on the admin page
- Added a custom tooltip to the pageviews chart showing formatted date/time, count, and %-change vs. the previous bucket
- Made the "Last 24 hours" range bucket by hour instead of day (auto-switches server-side when `days <= 1`), with a UTC note shown in the UI
- Removed the static `description` subtitle from every admin tab header (senators, static-pages, legislation list/detail, finance-hearings, analytics, budget) since it added noise without value

Closes #212