### PR TITLE
Render analytics graph timestamps in the viewer's local timezone

### DIFF
--- a/backend/app/routers/admin/analytics.py
+++ b/backend/app/routers/admin/analytics.py
@@ -55,7 +55,8 @@ def get_analytics_summary(
     )
 
     # A 1-day range is bucketed by hour (daily buckets would collapse to one point).
-    # Buckets are computed in the database's session timezone (UTC in production).
+    # Buckets are computed in the database's session timezone (UTC in production);
+    # DailyPageViewCountDTO attaches UTC tzinfo so clients render them in local time.
     bucket_col = (
         func.date_trunc("hour", PageView.created_at).label("day")
         if days <= 1

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -1,8 +1,8 @@
 """Analytics schemas — pageview ingest and admin summary DTOs."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class PageViewCreateDTO(BaseModel):
@@ -17,6 +17,14 @@ class DailyPageViewCountDTO(BaseModel):
     count: int
 
     model_config = ConfigDict(from_attributes=True)
+
+    # created_at is stored naive in the DB (UTC). Attach UTC tzinfo so the
+    # serialized timestamp carries an offset and clients parse it correctly
+    # instead of misreading it as local time.
+    @field_validator("day")
+    @classmethod
+    def _ensure_utc(cls, value: datetime) -> datetime:
+        return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
 
 
 class ActiveUsersDTO(BaseModel):

--- a/frontend/src/components/admin/AnalyticsCharts.tsx
+++ b/frontend/src/components/admin/AnalyticsCharts.tsx
@@ -67,13 +67,13 @@ function TopList({
   );
 }
 
-// Bucket timestamps are UTC (the database's session timezone); format in UTC
-// so the axis/tooltip stay consistent with how buckets were computed.
+// Bucket timestamps arrive as UTC instants (see DailyPageViewCountDTO); format
+// them without an explicit timeZone so they render in the viewer's local time.
 function formatBucketLabel(value: string, hourly: boolean): string {
   const date = new Date(value);
   return hourly
-    ? date.toLocaleTimeString("en-US", { hour: "numeric", timeZone: "UTC" })
-    : date.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+    ? date.toLocaleTimeString("en-US", { hour: "numeric" })
+    : date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
 function AnalyticsTooltip({
@@ -230,10 +230,7 @@ export function AnalyticsCharts({
       </div>
 
       <div>
-        <h3 className="mb-2 text-sm font-semibold text-slate-700">
-          Pageviews over time
-          {hourly && <span className="ml-2 text-xs font-normal text-slate-400">(times in UTC)</span>}
-        </h3>
+        <h3 className="mb-2 text-sm font-semibold text-slate-700">Pageviews over time</h3>
         <div className="h-72 w-full">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={summary.daily_pageviews}>


### PR DESCRIPTION
The analytics dashboard graph was displaying pageview timestamps that were
neither correctly UTC nor correctly local — timestamps returned by the API
were naive UTC datetimes with no offset, so the browser parsed them as
*local* time, and the chart then re-formatted that (already-shifted) value
with `timeZone: "UTC"`, compounding the error. Depending on the viewer's
timezone, the labeled times could be off by hours in either direction.

Changes:

- Added a validator on `DailyPageViewCountDTO.day` (backend/app/schemas/analytics.py)
  to attach UTC tzinfo to the naive datetime before serialization, so the
  API response carries a proper `Z` offset the client can parse unambiguously
- Removed the forced `timeZone: "UTC"` in `formatBucketLabel`
  (frontend/src/components/admin/AnalyticsCharts.tsx) so the chart now
  renders timestamps in the viewer's local timezone by default
- Dropped the now-inaccurate "(times in UTC)" label from the chart header
- Updated a stale comment in the admin analytics router explaining the
  UTC-tagging behavior

Closes #215