### PR TITLE
Replace onyen+password login with Onyen SSO and an accounts-based allowlist

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -41,3 +41,33 @@ SMTP_PORT = int(os.getenv("SMTP_PORT", 587))
 SMTP_USER = os.getenv("SMTP_USER")
 SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
 SMTP_FROM = os.getenv("SMTP_FROM", "speaker@unc.edu")
+
+# UNC Onyen SSO (SAML).
+#
+# SP side is our own registration with ITS (entity ID, ACS URL) — defaults below
+# match what was submitted. IdP side is UNC's, fetched and verified against
+# https://sso.unc.edu/metadata/idp on 2026-08-27; defaults below match that.
+# Overridable via env in case either ever needs to change without a code deploy.
+SAML_SP_ENTITY_ID = os.getenv("SAML_SP_ENTITY_ID", "https://senate.unc.edu")
+SAML_SP_ACS_URL = os.getenv(
+    "SAML_SP_ACS_URL",
+    "https://senate-backend-dept-undergraduate-senate.apps.cloudapps.unc.edu/api/auth/saml/acs",
+)
+# Our SP certificate/private key — never committed. Must be set via the
+# OpenShift secret (see deploy/cloudapps/template.yaml) before SSO can work;
+# the IdP requires signed AuthnRequests (WantAuthnRequestsSigned=true).
+SAML_SP_CERT = os.getenv("SAML_SP_CERT")
+SAML_SP_PRIVATE_KEY = os.getenv("SAML_SP_PRIVATE_KEY")
+
+SAML_IDP_ENTITY_ID = os.getenv("SAML_IDP_ENTITY_ID", "https://sso.unc.edu/idp")
+SAML_IDP_SSO_URL = os.getenv(
+    "SAML_IDP_SSO_URL", "https://sso.unc.edu/idp/profile/SAML2/Redirect/SSO"
+)
+SAML_IDP_CERT = os.getenv(
+    "SAML_IDP_CERT",
+    "MIIC/zCCAeegAwIBAgIJAKbdYCfHuaO6MA0GCSqGSIb3DQEBCwUAMBYxFDASBgNVBAMMC3Nzby51bmMuZWR1MB4XDTE2MDgxMjE1MzUyMFoXDTM2MDgxMjE1MzUyMFowFjEUMBIGA1UEAwwLc3NvLnVuYy5lZHUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCclewnsUf+I4ykc+gHILGPVCMkT4AoLOchiXYzk21KhlaKlpj6LoQokZG381V53jST4tl9kq8cK6hgDa7Sr9uAtH/AYfNNmNjVpmZho6zPsZzrmH9UJ7MID8Nd2H4YpTb4MTPhhf10nCiVd6TIuuNw5WVa79Bfoas8eKR25aTQgZAci+bGAURjJxCxBZTI2mG2kVymTW6mk4/g9LmzerQerAQtqNHZJ9cwDv6kFnvv6TIMDaSOMgPsU4rAWyPO7yBi4fmjWLtuEzo3ld4mPQQ0FwqHa6E/gIgqDbj4akfT5mbS726WjGK8qqJxeq4oN5mhkLC0xpdvLuqldRl9max/AgMBAAGjUDBOMB0GA1UdDgQWBBT6sAuFGcdqPD1zPa8aNO2gMUIJUTAfBgNVHSMEGDAWgBT6sAuFGcdqPD1zPa8aNO2gMUIJUTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAK2oJw+TWofs88vOvmC3UBm0buOP7nsVGoVALhIbn5ZpmNz6uTrHnyMBmjEBXx1/3br7JkzMdcTX/BamHrgfzhTp1WutCJZ5OtVZGv+ADX3g1o/dN4612wl29+6rFrAKIxfFbpK4VZtp9l1UXUQhkR62ShU0+iT+Aku5g4Pmi5iMkqcPBGwkHLw8enbCUdaRftpYGkvfXPKnhYlGAFmfCB1Qb8xMsjIZghf+XXsM5rq4IxnOPLaWGbmlKOqLMcm4s+ToxdeOKEyNWYnLRrYhQH5Onj/0AX9U+unabDJzCBUng/vVPjlhQOuoX24oTjN4LMnBr7sy3/SJbBLZ0AU8n8",
+)
+
+# Where to redirect the browser back to once SSO completes. Reuses the first
+# configured CORS origin (the frontend) rather than adding a separate param.
+FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", CORS_ORIGINS[0] if CORS_ORIGINS else "")

--- a/backend/app/models/Admin.py
+++ b/backend/app/models/Admin.py
@@ -15,7 +15,8 @@ class Admin(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     onyen: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
-    password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Nullable: accounts are provisioned via the Onyen SSO allowlist and have no local password.
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
     first_name: Mapped[str] = mapped_column(String(100), nullable=False)
     last_name: Mapped[str] = mapped_column(String(100), nullable=False)
     role: Mapped[str] = mapped_column(String(20), nullable=False)  # "admin" or "staff"

--- a/backend/app/routers/admin/accounts.py
+++ b/backend/app/routers/admin/accounts.py
@@ -16,7 +16,6 @@ from app.models.Admin import Admin
 from app.schemas.account import AccountDTO, CreateAccountDTO, UpdateAccountDTO
 from app.schemas.pagination import PaginatedResponse
 from app.utils.pagination import paginate
-from app.utils.passwords import hash_password
 
 router = APIRouter(
     prefix="/api/admin/accounts",
@@ -49,9 +48,7 @@ def create_admin_account(
     db: Session = Depends(get_db),
 ):
     """Create an admin or staff account. Admin role required."""
-    account_data = body.model_dump()
-    password = account_data.pop("password")
-    account = Admin(**account_data, password_hash=hash_password(password))
+    account = Admin(**body.model_dump())
     db.add(account)
     try:
         db.commit()
@@ -82,11 +79,7 @@ def update_admin_account(
         raise HTTPException(status_code=404, detail="Account not found")
 
     for field, value in body.model_dump(exclude_unset=True).items():
-        if field == "password":
-            if value is not None:
-                account.password_hash = hash_password(value)
-        else:
-            setattr(account, field, value)
+        setattr(account, field, value)
 
     try:
         db.commit()

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,26 +1,28 @@
-from datetime import datetime, timedelta
-from typing import Dict, List, Tuple
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field, field_validator
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel, field_validator
 from sqlalchemy.orm import Session
 
+from app.config import ENVIRONMENT, FRONTEND_BASE_URL
 from app.database import get_db
 from app.models import Admin
-from app.schemas.account import MAX_PASSWORD_LENGTH, validate_onyen
+from app.saml import (
+    build_saml_auth,
+    build_saml_request_data,
+    extract_onyen,
+    saml_configured,
+)
+from app.schemas.account import validate_onyen
 from app.utils.auth import create_access_token, get_current_user, require_role
-from app.utils.passwords import verify_password
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
-
-MAX_FAILED_LOGIN_ATTEMPTS = 5
-FAILED_LOGIN_WINDOW = timedelta(minutes=15)
-failed_login_attempts: Dict[Tuple[str, str], List[datetime]] = {}
+logger = logging.getLogger(__name__)
 
 
-class LoginRequest(BaseModel):
+class DevLoginRequest(BaseModel):
     onyen: str
-    password: str = Field(min_length=1, max_length=MAX_PASSWORD_LENGTH)
 
     @field_validator("onyen")
     @classmethod
@@ -28,47 +30,97 @@ class LoginRequest(BaseModel):
         return validate_onyen(value)
 
 
-def _login_rate_limit_key(request: Request, onyen: str) -> tuple[str, str]:
-    client_ip = request.client.host if request.client else "unknown"
-    return client_ip, onyen
+@router.post("/dev-login")
+def dev_login(payload: DevLoginRequest, db: Session = Depends(get_db)):
+    """Local-only login bypass for onyens already on the accounts allowlist.
+
+    Stands in for the real SSO round-trip during development, since there's
+    no way to hit UNC's IdP from a non-registered dev/staging environment.
+    Never available in production — SAML SSO is the only login path there.
+    """
+    if ENVIRONMENT == "production":
+        raise HTTPException(status_code=404)
+
+    user = db.query(Admin).filter(Admin.onyen == payload.onyen).first()
+    if not user:
+        raise HTTPException(status_code=401, detail="No account with that onyen")
+
+    token = create_access_token(data={"sub": str(user.id)})
+    return {"access_token": token, "token_type": "bearer"}
 
 
-def check_login_rate_limit(request: Request, onyen: str) -> None:
-    key = _login_rate_limit_key(request, onyen)
-    now = datetime.now()
-    cutoff_time = now - FAILED_LOGIN_WINDOW
-    attempts = [attempt for attempt in failed_login_attempts.get(key, []) if attempt > cutoff_time]
-    failed_login_attempts[key] = attempts
+def _request_port(request: Request) -> int:
+    if request.url.port:
+        return request.url.port
+    return 443 if request.url.scheme == "https" else 80
 
-    if len(attempts) >= MAX_FAILED_LOGIN_ATTEMPTS:
+
+@router.get("/saml/login")
+async def saml_login_redirect(request: Request, next: str = "/admin"):
+    if not saml_configured():
         raise HTTPException(
-            status_code=429,
-            detail="Too many failed login attempts. Try again later.",
+            status_code=503,
+            detail="Onyen SSO is not yet configured. Contact an admin.",
         )
 
+    request_data = build_saml_request_data(
+        scheme=request.url.scheme,
+        host=request.url.hostname or "",
+        port=_request_port(request),
+        path=request.url.path,
+        get_params=dict(request.query_params),
+        post_params={},
+    )
+    auth = build_saml_auth(request_data)
+    redirect_url = auth.login(return_to=next)
+    return RedirectResponse(redirect_url)
 
-def record_failed_login(request: Request, onyen: str) -> None:
-    key = _login_rate_limit_key(request, onyen)
-    failed_login_attempts.setdefault(key, []).append(datetime.now())
 
+@router.post("/saml/acs")
+async def saml_acs(request: Request, db: Session = Depends(get_db)):
+    if not saml_configured():
+        raise HTTPException(status_code=503, detail="Onyen SSO is not yet configured.")
 
-def clear_failed_logins(request: Request, onyen: str) -> None:
-    failed_login_attempts.pop(_login_rate_limit_key(request, onyen), None)
+    form = await request.form()
+    post_params = dict(form)
 
+    request_data = build_saml_request_data(
+        scheme=request.url.scheme,
+        host=request.url.hostname or "",
+        port=_request_port(request),
+        path=request.url.path,
+        get_params=dict(request.query_params),
+        post_params=post_params,
+    )
+    auth = build_saml_auth(request_data)
+    auth.process_response()
 
-@router.post("/login")
-def login(payload: LoginRequest, request: Request, db: Session = Depends(get_db)):
-    check_login_rate_limit(request, payload.onyen)
-    user = db.query(Admin).filter(Admin.onyen == payload.onyen).first()
+    errors = auth.get_errors()
+    if errors:
+        logger.warning("SAML ACS validation failed: %s", auth.get_last_error_reason())
+        raise HTTPException(status_code=401, detail="SSO sign-in failed. Contact an admin.")
 
-    if not user or not verify_password(payload.password, user.password_hash):
-        record_failed_login(request, payload.onyen)
-        raise HTTPException(status_code=401, detail="Invalid credentials")
+    if not auth.is_authenticated():
+        raise HTTPException(status_code=401, detail="SSO sign-in failed.")
 
-    clear_failed_logins(request, payload.onyen)
+    attributes = auth.get_attributes()
+    name_id = auth.get_nameid()
+    onyen = extract_onyen(attributes, name_id)
+
+    logger.info("SAML login attempt. NameID=%s onyen=%s attributes=%s", name_id, onyen, attributes)
+
+    user = db.query(Admin).filter(Admin.onyen == onyen).first() if onyen else None
+    next_path = post_params.get("RelayState") or "/admin"
+
+    if not user:
+        logger.info("SAML login rejected — %r is not on the accounts allowlist", onyen)
+        return RedirectResponse(f"{FRONTEND_BASE_URL}/admin/login?error=no_access", status_code=303)
+
     token = create_access_token(data={"sub": str(user.id)})
-
-    return {"access_token": token, "token_type": "bearer"}
+    return RedirectResponse(
+        f"{FRONTEND_BASE_URL}/admin/sso-callback#token={token}&next={next_path}",
+        status_code=303,
+    )
 
 
 @router.get("/me")

--- a/backend/app/saml.py
+++ b/backend/app/saml.py
@@ -1,0 +1,121 @@
+"""SAML SP integration for UNC Onyen SSO.
+
+IdP metadata (entity ID, SSO URL, signing cert) comes from UNC ITS's IdP
+metadata endpoint (https://sso.unc.edu/metadata/idp), verified 2026-08-27 —
+see app.config. SP credentials (our certificate/private key) must come from
+the OpenShift secret; see deploy/cloudapps/template.yaml.
+
+Attribute names below (ONYEN_ATTRIBUTE_CANDIDATES / EMAIL_ATTRIBUTE_CANDIDATES)
+are best-guess eduPerson/InCommon conventions — ITS hasn't confirmed the exact
+attribute names they'll release. saml_acs() logs the raw attribute dict on
+every login attempt so the real names can be confirmed against the first live
+test and this list adjusted.
+"""
+
+import logging
+
+from onelogin.saml2.auth import OneLogin_Saml2_Auth
+
+from app.config import (
+    SAML_IDP_CERT,
+    SAML_IDP_ENTITY_ID,
+    SAML_IDP_SSO_URL,
+    SAML_SP_ACS_URL,
+    SAML_SP_CERT,
+    SAML_SP_ENTITY_ID,
+    SAML_SP_PRIVATE_KEY,
+)
+
+logger = logging.getLogger(__name__)
+
+# Tried in order against the assertion's attribute dict.
+ONYEN_ATTRIBUTE_CANDIDATES = [
+    "uid",
+    "onyen",
+    "urn:oid:0.9.2342.19200300.100.1.1",  # eduPerson uid
+]
+EMAIL_ATTRIBUTE_CANDIDATES = [
+    "mail",
+    "email",
+    "urn:oid:0.9.2342.19200300.100.1.3",  # eduPerson mail
+]
+
+
+def saml_configured() -> bool:
+    """Whether we have everything needed to actually talk to the IdP.
+
+    The IdP side is baked into defaults (see app.config); the SP cert/key
+    are the piece that only exists once someone provisions the OpenShift
+    secret, so that's what gates this in practice.
+    """
+    return bool(SAML_SP_CERT and SAML_SP_PRIVATE_KEY and SAML_IDP_CERT)
+
+
+def saml_settings() -> dict:
+    return {
+        "strict": True,
+        "debug": False,
+        "sp": {
+            "entityId": SAML_SP_ENTITY_ID,
+            "assertionConsumerService": {
+                "url": SAML_SP_ACS_URL,
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+            },
+            "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+            "x509cert": SAML_SP_CERT or "",
+            "privateKey": SAML_SP_PRIVATE_KEY or "",
+        },
+        "idp": {
+            "entityId": SAML_IDP_ENTITY_ID,
+            "singleSignOnService": {
+                "url": SAML_IDP_SSO_URL,
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+            },
+            "x509cert": SAML_IDP_CERT or "",
+        },
+        "security": {
+            # ITS's IdP metadata sets WantAuthnRequestsSigned="true" — unsigned
+            # requests will be rejected, this isn't optional.
+            "authnRequestsSigned": True,
+            "wantAssertionsSigned": True,
+            "wantMessagesSigned": False,
+            "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+            "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
+        },
+    }
+
+
+def build_saml_request_data(
+    scheme: str, host: str, port: int, path: str, get_params: dict, post_params: dict
+) -> dict:
+    return {
+        "https": "on" if scheme == "https" else "off",
+        "http_host": host,
+        "server_port": port,
+        "script_name": path,
+        "get_data": get_params,
+        "post_data": post_params,
+    }
+
+
+def build_saml_auth(request_data: dict) -> OneLogin_Saml2_Auth:
+    return OneLogin_Saml2_Auth(request_data, saml_settings())
+
+
+def extract_onyen(attributes: dict, name_id: str | None) -> str | None:
+    for key in ONYEN_ATTRIBUTE_CANDIDATES:
+        values = attributes.get(key)
+        if values:
+            return values[0]
+    # Fall back to NameID — plausible for a non-federated in-house IdP where
+    # the persistent identifier is just the onyen itself rather than an
+    # opaque pairwise ID.
+    return name_id
+
+
+def extract_email(attributes: dict) -> str | None:
+    for key in EMAIL_ATTRIBUTE_CANDIDATES:
+        values = attributes.get(key)
+        if values:
+            return values[0]
+    return None

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -3,11 +3,9 @@
 import re
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
 
 ONYEN_PATTERN = re.compile(r"^[A-Za-z0-9._-]{2,64}$")
-MIN_PASSWORD_LENGTH = 12
-MAX_PASSWORD_LENGTH = 128
 
 
 def normalize_onyen(value: str) -> str:
@@ -37,7 +35,6 @@ class AccountDTO(BaseModel):
 class CreateAccountDTO(BaseModel):
     email: EmailStr
     onyen: str
-    password: str = Field(min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH)
     first_name: str
     last_name: str
     role: Literal["admin", "staff"]
@@ -51,9 +48,6 @@ class CreateAccountDTO(BaseModel):
 class UpdateAccountDTO(BaseModel):
     email: EmailStr | None = None
     onyen: str | None = None
-    password: str | None = Field(
-        default=None, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH
-    )
     first_name: str | None = None
     last_name: str | None = None
     role: Literal["admin", "staff"] | None = None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "sqlalchemy==2.0.38",
   "psycopg2-binary==2.9.10",
   "python-jose[cryptography]==3.3.0",
+  "python3-saml==1.16.0",
   "bleach==6.1.0",
   "python-multipart==0.0.20",
   "Pillow==11.2.1",

--- a/backend/requirements.prod.txt
+++ b/backend/requirements.prod.txt
@@ -18,6 +18,9 @@ bleach==6.1.0
 # JSON Web Token
 python-jose[cryptography]==3.3.0
 
+# SAML SSO (UNC Onyen)
+python3-saml==1.16.0
+
 # Uploads & image processing
 python-multipart==0.0.20
 Pillow==11.2.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,6 +26,9 @@ bleach==6.1.0
 # JSON Web Token
 python-jose[cryptography]==3.3.0
 
+# SAML SSO (UNC Onyen)
+python3-saml==1.16.0
+
 # Uploads & image processing
 python-multipart==0.0.20
 Pillow==11.2.1

--- a/backend/script/init_db.py
+++ b/backend/script/init_db.py
@@ -23,9 +23,8 @@ from app.database import (
     engine,
 )
 from app.models import Admin  # noqa: F401 - importing app.models registers all tables
-from app.schemas.account import MIN_PASSWORD_LENGTH, validate_onyen
+from app.schemas.account import validate_onyen
 from app.static_pages import ensure_default_static_pages
-from app.utils.passwords import hash_password
 
 
 def create_missing_tables() -> None:
@@ -66,33 +65,46 @@ def sync_missing_columns() -> None:
                 conn.execute(text(f"ALTER TABLE {table.name} ADD COLUMN {column_ddl}"))
                 print(f"Added missing column {table.name}.{column.name}")
 
+            # A column that already exists but became nullable on the model
+            # (e.g. Admin.password_hash once accounts stopped requiring a
+            # local password) needs its NOT NULL constraint relaxed too —
+            # ADD COLUMN above only handles columns that don't exist yet.
+            existing_column_info = {col["name"]: col for col in inspector.get_columns(table.name)}
+            for column in table.columns:
+                info = existing_column_info.get(column.name)
+                if info is None:
+                    continue  # just added above, already matches the model
+                if column.nullable and not info["nullable"]:
+                    conn.execute(
+                        text(f"ALTER TABLE {table.name} ALTER COLUMN {column.name} DROP NOT NULL")
+                    )
+                    print(f"Relaxed NOT NULL on {table.name}.{column.name}")
+
 
 def bootstrap_initial_admin() -> None:
+    """Add the first onyen to the accounts allowlist so someone can log in via SSO.
+
+    No password: accounts are provisioned by onyen and authenticate through
+    UNC's Onyen SSO (or the dev-only bypass login outside production).
+    """
     email = os.getenv("INITIAL_ADMIN_EMAIL")
     onyen = os.getenv("INITIAL_ADMIN_ONYEN")
-    password = os.getenv("INITIAL_ADMIN_PASSWORD")
     first_name = os.getenv("INITIAL_ADMIN_FIRST_NAME", "Initial")
     last_name = os.getenv("INITIAL_ADMIN_LAST_NAME", "Admin")
     role = os.getenv("INITIAL_ADMIN_ROLE", "admin")
 
-    if not email and not onyen and not password:
+    if not email and not onyen:
         print("No initial admin requested")
         return
 
-    if not email or not onyen or not password:
-        print(
-            "INITIAL_ADMIN_EMAIL, INITIAL_ADMIN_ONYEN, and INITIAL_ADMIN_PASSWORD must be set together"
-        )
+    if not email or not onyen:
+        print("INITIAL_ADMIN_EMAIL and INITIAL_ADMIN_ONYEN must be set together")
         sys.exit(1)
 
     try:
         onyen = validate_onyen(onyen)
     except ValueError as exc:
         print(str(exc))
-        sys.exit(1)
-
-    if len(password) < MIN_PASSWORD_LENGTH:
-        print(f"INITIAL_ADMIN_PASSWORD must be at least {MIN_PASSWORD_LENGTH} characters")
         sys.exit(1)
 
     if role not in {"admin", "staff"}:
@@ -110,7 +122,6 @@ def bootstrap_initial_admin() -> None:
         admin = Admin(
             email=email,
             onyen=onyen,
-            password_hash=hash_password(password),
             first_name=first_name,
             last_name=last_name,
             role=role,

--- a/backend/script/seed_data.py
+++ b/backend/script/seed_data.py
@@ -39,7 +39,6 @@ from app.models import (
     StaticPageContent,
 )
 from app.static_pages import STATIC_PAGE_DEFAULTS
-from app.utils.passwords import hash_password
 
 CURRENT_SESSION = 111
 
@@ -101,28 +100,18 @@ def clear_existing_data(db: Session) -> None:
 def seed_admins(db: Session) -> list[Admin]:
     admins = [
         Admin(
-            email="alex.thompson@unc.edu",
-            onyen="athompson",
-            password_hash=hash_password("SenateDev2026!"),
-            first_name="Alex",
-            last_name="Thompson",
+            email="calebhan@unc.edu",
+            onyen="calebhan",
+            first_name="Caleb",
+            last_name="Han",
             role="admin",
         ),
         Admin(
-            email="morgan.lee@unc.edu",
-            onyen="mlee",
-            password_hash=hash_password("SenateDev2026!"),
-            first_name="Morgan",
-            last_name="Lee",
+            email="mmines@unc.edu",
+            onyen="mmines",
+            first_name="Mason",
+            last_name="Mines",
             role="admin",
-        ),
-        Admin(
-            email="jordan.rivera@unc.edu",
-            onyen="jrivera",
-            password_hash=hash_password("SenateDev2026!"),
-            first_name="Jordan",
-            last_name="Rivera",
-            role="staff",
         ),
     ]
     db.add_all(admins)
@@ -144,15 +133,10 @@ def seed_sections(db: Session, admins: list[Admin]) -> None:
     db.flush()
 
     admin_sections = [
-        AdminSections(section_id=section.id, admin_id=admins[0].id) for section in sections
+        AdminSections(section_id=section.id, admin_id=admin.id)
+        for section in sections
+        for admin in admins
     ]
-    admin_sections.extend(
-        [
-            AdminSections(section_id=sections[0].id, admin_id=admins[1].id),
-            AdminSections(section_id=sections[1].id, admin_id=admins[1].id),
-            AdminSections(section_id=sections[4].id, admin_id=admins[2].id),
-        ]
-    )
     db.add_all(admin_sections)
 
 

--- a/backend/tests/routers/test_auth.py
+++ b/backend/tests/routers/test_auth.py
@@ -1,9 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
-import pytest
 from jose import jwt
 
-import app.routers.auth as auth_router
 from app.config import ACCESS_TOKEN_EXPIRE_HOURS, JWT_ALGORITHM, JWT_SECRET
 
 # -----------------------------
@@ -11,39 +9,27 @@ from app.config import ACCESS_TOKEN_EXPIRE_HOURS, JWT_ALGORITHM, JWT_SECRET
 # -----------------------------
 
 
-@pytest.fixture(autouse=True)
-def clear_login_rate_limits():
-    auth_router.failed_login_attempts.clear()
-    yield
-    auth_router.failed_login_attempts.clear()
-
-
-def test_valid_login(client, seeded_admins):
-    response = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "TestPassword123!"}
-    )
+def test_dev_login_known_onyen(client, seeded_admins):
+    response = client.post("/api/auth/dev-login", json={"onyen": "user123456789"})
     assert response.status_code == 200
     data = response.json()
     assert "access_token" in data
     assert data["token_type"] == "bearer"
 
 
-def test_invalid_credentials(client, seeded_admins):
-    response = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "WrongPassword123!"}
-    )
+def test_dev_login_unknown_onyen(client, seeded_admins):
+    response = client.post("/api/auth/dev-login", json={"onyen": "notexist"})
     assert response.status_code == 401
 
-    response2 = client.post(
-        "/api/auth/login", json={"onyen": "notexist", "password": "TestPassword123!"}
-    )
-    assert response2.status_code == 401
+
+def test_dev_login_disabled_in_production(client, seeded_admins, monkeypatch):
+    monkeypatch.setattr("app.routers.auth.ENVIRONMENT", "production")
+    response = client.post("/api/auth/dev-login", json={"onyen": "user123456789"})
+    assert response.status_code == 404
 
 
 def test_me_endpoint_with_valid_token(client, seeded_admins):
-    login = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "TestPassword123!"}
-    )
+    login = client.post("/api/auth/dev-login", json={"onyen": "user123456789"})
     token = login.json()["access_token"]
 
     response = client.get("/api/auth/me", headers={"Authorization": f"Bearer {token}"})
@@ -67,10 +53,8 @@ def test_expired_token(client, seeded_admins):
 
 
 def test_role_check(client, seeded_admins):
-    # login as a normal user
-    login = client.post(
-        "/api/auth/login", json={"onyen": "user987654321", "password": "TestPassword123!"}
-    )
+    # log in as a normal (staff) user
+    login = client.post("/api/auth/dev-login", json={"onyen": "user987654321"})
     token = login.json()["access_token"]
 
     # access an admin-only route
@@ -78,9 +62,7 @@ def test_role_check(client, seeded_admins):
     assert response.status_code == 403
 
     # access with admin token
-    login_admin = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "TestPassword123!"}
-    )
+    login_admin = client.post("/api/auth/dev-login", json={"onyen": "user123456789"})
     admin_token = login_admin.json()["access_token"]
     response2 = client.get(
         "/api/auth/admin-only", headers={"Authorization": f"Bearer {admin_token}"}
@@ -88,29 +70,11 @@ def test_role_check(client, seeded_admins):
     assert response2.status_code == 200
 
 
-def test_login_rejects_too_long_password(client, seeded_admins):
-    response = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "x" * 129}
-    )
-    assert response.status_code == 422
+def test_saml_login_unconfigured_returns_503(client):
+    response = client.get("/api/auth/saml/login", follow_redirects=False)
+    assert response.status_code == 503
 
 
-def test_successful_login_clears_failed_attempts(client, seeded_admins):
-    bad_payload = {"onyen": "user123456789", "password": "WrongPassword123!"}
-    good_payload = {"onyen": "user123456789", "password": "TestPassword123!"}
-
-    assert client.post("/api/auth/login", json=bad_payload).status_code == 401
-    assert auth_router.failed_login_attempts
-
-    assert client.post("/api/auth/login", json=good_payload).status_code == 200
-    assert auth_router.failed_login_attempts == {}
-
-
-def test_failed_login_rate_limited(client, seeded_admins):
-    payload = {"onyen": "user123456789", "password": "WrongPassword123!"}
-
-    for _ in range(auth_router.MAX_FAILED_LOGIN_ATTEMPTS):
-        assert client.post("/api/auth/login", json=payload).status_code == 401
-
-    response = client.post("/api/auth/login", json=payload)
-    assert response.status_code == 429
+def test_saml_acs_unconfigured_returns_503(client):
+    response = client.post("/api/auth/saml/acs")
+    assert response.status_code == 503

--- a/backend/tests/routers/test_legislation.py
+++ b/backend/tests/routers/test_legislation.py
@@ -29,7 +29,7 @@ def create_action_payload():
 
 def test_create_legislation(client, seeded_admins):
     login = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "TestPassword123!"}
+        "/api/auth/dev-login", json={"onyen": "user123456789"}
     )
     token = login.json()["access_token"]
 
@@ -46,7 +46,7 @@ def test_create_legislation(client, seeded_admins):
 
 def test_add_legislation_action(client, seeded_admins):
     login = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "TestPassword123!"}
+        "/api/auth/dev-login", json={"onyen": "user123456789"}
     )
     token = login.json()["access_token"]
 
@@ -74,7 +74,7 @@ def test_add_legislation_action(client, seeded_admins):
 
 def test_update_legislation(client, seeded_admins):
     login = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "TestPassword123!"}
+        "/api/auth/dev-login", json={"onyen": "user123456789"}
     )
     token = login.json()["access_token"]
     # Create legislation
@@ -97,7 +97,7 @@ def test_update_legislation(client, seeded_admins):
 
 def test_update_legislation_action(client, seeded_admins):
     login = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "TestPassword123!"}
+        "/api/auth/dev-login", json={"onyen": "user123456789"}
     )
     token = login.json()["access_token"]
     # Create legislation and action
@@ -148,7 +148,7 @@ def test_update_legislation_action(client, seeded_admins):
 
 def test_delete_legislation_action(client, seeded_admins):
     login = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "TestPassword123!"}
+        "/api/auth/dev-login", json={"onyen": "user123456789"}
     )
     token = login.json()["access_token"]
     # Create legislation and action
@@ -196,7 +196,7 @@ def test_delete_legislation_action(client, seeded_admins):
 
 def test_delete_legislation_and_cascade_actions(client, seeded_admins):
     login = client.post(
-        "/api/auth/login", json={"onyen": "user123456789", "password": "TestPassword123!"}
+        "/api/auth/dev-login", json={"onyen": "user123456789"}
     )
     token = login.json()["access_token"]
     # Create legislation

--- a/backend/tests/routes/test_admin_accounts.py
+++ b/backend/tests/routes/test_admin_accounts.py
@@ -162,7 +162,6 @@ def write_staff_client(write_engine):
 _CREATE_PAYLOAD = {
     "email": "newuser@unc.edu",
     "onyen": "newuser",
-    "password": "TestPassword123!",
     "first_name": "New",
     "last_name": "User",
     "role": "staff",

--- a/backend/tests/schemas/test_account_schemas.py
+++ b/backend/tests/schemas/test_account_schemas.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from app.schemas.account import AccountDTO, CreateAccountDTO, UpdateAccountDTO
+from app.schemas.account import AccountDTO, CreateAccountDTO
 
 
 class TestCreateAccountDTO:
@@ -11,7 +11,6 @@ class TestCreateAccountDTO:
         dto = CreateAccountDTO(
             email="user@unc.edu",
             onyen="JaneDoe",
-            password="TestPassword123!",
             first_name="Jane",
             last_name="Doe",
             role="admin",
@@ -24,7 +23,6 @@ class TestCreateAccountDTO:
             CreateAccountDTO(
                 email="user@unc.edu",
                 onyen="x",
-                password="TestPassword123!",
                 first_name="Jane",
                 last_name="Doe",
                 role="admin",
@@ -35,18 +33,6 @@ class TestCreateAccountDTO:
             CreateAccountDTO(
                 email="user@unc.edu",
                 onyen="jane doe",
-                password="TestPassword123!",
-                first_name="Jane",
-                last_name="Doe",
-                role="admin",
-            )
-
-    def test_invalid_password_too_short(self):
-        with pytest.raises(ValidationError):
-            CreateAccountDTO(
-                email="user@unc.edu",
-                onyen="janedoe",
-                password="short",
                 first_name="Jane",
                 last_name="Doe",
                 role="admin",
@@ -57,7 +43,6 @@ class TestCreateAccountDTO:
             CreateAccountDTO(
                 email="not-an-email",
                 onyen="janedoe",
-                password="TestPassword123!",
                 first_name="Jane",
                 last_name="Doe",
                 role="admin",
@@ -68,7 +53,6 @@ class TestCreateAccountDTO:
             CreateAccountDTO(
                 email="user@unc.edu",
                 onyen="janedoe",
-                password="TestPassword123!",
                 first_name="Jane",
                 last_name="Doe",
                 role="superuser",
@@ -78,18 +62,11 @@ class TestCreateAccountDTO:
         dto = CreateAccountDTO(
             email="user@unc.edu",
             onyen="janedoe",
-            password="TestPassword123!",
             first_name="Jane",
             last_name="Doe",
             role="staff",
         )
         assert dto.role == "staff"
-
-
-class TestUpdateAccountDTO:
-    def test_password_is_optional(self):
-        dto = UpdateAccountDTO(first_name="Jane")
-        assert dto.password is None
 
 
 class TestAccountDTO:

--- a/backend/tests/test_saml.py
+++ b/backend/tests/test_saml.py
@@ -1,0 +1,36 @@
+from app.saml import extract_email, extract_onyen, saml_configured
+
+
+def test_extract_onyen_from_uid_attribute():
+    attributes = {"uid": ["jdoe"], "mail": ["jdoe@unc.edu"]}
+    assert extract_onyen(attributes, name_id="opaque-id") == "jdoe"
+
+
+def test_extract_onyen_falls_back_to_name_id():
+    assert extract_onyen({}, name_id="jdoe") == "jdoe"
+
+
+def test_extract_onyen_returns_none_without_attribute_or_name_id():
+    assert extract_onyen({}, name_id=None) is None
+
+
+def test_extract_email_from_mail_attribute():
+    assert extract_email({"mail": ["jdoe@unc.edu"]}) == "jdoe@unc.edu"
+
+
+def test_extract_email_returns_none_when_absent():
+    assert extract_email({"uid": ["jdoe"]}) is None
+
+
+def test_saml_configured_false_without_sp_credentials(monkeypatch):
+    monkeypatch.setattr("app.saml.SAML_SP_CERT", None)
+    monkeypatch.setattr("app.saml.SAML_SP_PRIVATE_KEY", "key")
+    monkeypatch.setattr("app.saml.SAML_IDP_CERT", "cert")
+    assert saml_configured() is False
+
+
+def test_saml_configured_true_with_all_credentials(monkeypatch):
+    monkeypatch.setattr("app.saml.SAML_SP_CERT", "cert")
+    monkeypatch.setattr("app.saml.SAML_SP_PRIVATE_KEY", "key")
+    monkeypatch.setattr("app.saml.SAML_IDP_CERT", "idp-cert")
+    assert saml_configured() is True

--- a/deploy/cloudapps/scripts/apply-secrets.sh
+++ b/deploy/cloudapps/scripts/apply-secrets.sh
@@ -21,6 +21,8 @@ existing_smtp_port="$(get_secret_value "$SECRET_NAME" SMTP_PORT)"
 existing_smtp_user="$(get_secret_value "$SECRET_NAME" SMTP_USER)"
 existing_smtp_password="$(get_secret_value "$SECRET_NAME" SMTP_PASSWORD)"
 existing_smtp_from="$(get_secret_value "$SECRET_NAME" SMTP_FROM)"
+existing_saml_sp_cert="$(get_secret_value "$SECRET_NAME" SAML_SP_CERT)"
+existing_saml_sp_key="$(get_secret_value "$SECRET_NAME" SAML_SP_PRIVATE_KEY)"
 
 DB_PASSWORD="${DB_PASSWORD:-${existing_db:-$(generate_sql_password)}}"
 MSSQL_SA_PASSWORD="${MSSQL_SA_PASSWORD:-${existing_mssql:-$(generate_sql_password)}}"
@@ -31,6 +33,11 @@ SMTP_PORT="${SMTP_PORT:-${existing_smtp_port:-587}}"
 SMTP_USER="${SMTP_USER:-${existing_smtp_user:-}}"
 SMTP_PASSWORD="${SMTP_PASSWORD:-${existing_smtp_password:-}}"
 SMTP_FROM="${SMTP_FROM:-${existing_smtp_from:-speaker@unc.edu}}"
+# SP certificate/private key for Onyen SSO (SAML). Generated with:
+#   openssl req -x509 -newkey rsa:2048 -nodes -keyout sp.key -out sp.crt -days 3650 -subj "/CN=senate.unc.edu"
+# Leave unset until that keypair exists — SSO login just stays unconfigured (503) until it's set.
+SAML_SP_CERT="${SAML_SP_CERT:-${existing_saml_sp_cert:-}}"
+SAML_SP_PRIVATE_KEY="${SAML_SP_PRIVATE_KEY:-${existing_saml_sp_key:-}}"
 
 oc create secret generic "$SECRET_NAME" \
   --from-literal=DB_PASSWORD="$DB_PASSWORD" \
@@ -42,6 +49,8 @@ oc create secret generic "$SECRET_NAME" \
   --from-literal=SMTP_USER="$SMTP_USER" \
   --from-literal=SMTP_PASSWORD="$SMTP_PASSWORD" \
   --from-literal=SMTP_FROM="$SMTP_FROM" \
+  --from-literal=SAML_SP_CERT="$SAML_SP_CERT" \
+  --from-literal=SAML_SP_PRIVATE_KEY="$SAML_SP_PRIVATE_KEY" \
   --dry-run=client \
   -o yaml \
   | oc apply -f -

--- a/deploy/cloudapps/scripts/bootstrap-admin.sh
+++ b/deploy/cloudapps/scripts/bootstrap-admin.sh
@@ -30,7 +30,6 @@ read_prompt() {
 
 read_prompt INITIAL_ADMIN_EMAIL "Initial admin email: "
 read_prompt INITIAL_ADMIN_ONYEN "Initial admin Onyen: "
-read_prompt INITIAL_ADMIN_PASSWORD "Initial admin password: " 1
 read_prompt INITIAL_ADMIN_FIRST_NAME "Initial admin first name: "
 read_prompt INITIAL_ADMIN_LAST_NAME "Initial admin last name: "
 INITIAL_ADMIN_ROLE="${INITIAL_ADMIN_ROLE:-admin}"
@@ -40,7 +39,6 @@ TEMP_SECRET="${APP_NAME}-initial-admin"
 oc create secret generic "$TEMP_SECRET" \
   --from-literal=INITIAL_ADMIN_EMAIL="$INITIAL_ADMIN_EMAIL" \
   --from-literal=INITIAL_ADMIN_ONYEN="$INITIAL_ADMIN_ONYEN" \
-  --from-literal=INITIAL_ADMIN_PASSWORD="$INITIAL_ADMIN_PASSWORD" \
   --from-literal=INITIAL_ADMIN_FIRST_NAME="$INITIAL_ADMIN_FIRST_NAME" \
   --from-literal=INITIAL_ADMIN_LAST_NAME="$INITIAL_ADMIN_LAST_NAME" \
   --from-literal=INITIAL_ADMIN_ROLE="$INITIAL_ADMIN_ROLE" \
@@ -50,7 +48,7 @@ oc create secret generic "$TEMP_SECRET" \
 
 cleanup() {
   oc set env "deployment/${APP_NAME}-backend" \
-    INITIAL_ADMIN_EMAIL- INITIAL_ADMIN_ONYEN- INITIAL_ADMIN_PASSWORD- INITIAL_ADMIN_FIRST_NAME- \
+    INITIAL_ADMIN_EMAIL- INITIAL_ADMIN_ONYEN- INITIAL_ADMIN_FIRST_NAME- \
     INITIAL_ADMIN_LAST_NAME- INITIAL_ADMIN_ROLE- >/dev/null 2>&1 || true
   oc delete secret "$TEMP_SECRET" --ignore-not-found >/dev/null 2>&1 || true
 }

--- a/deploy/cloudapps/template.yaml
+++ b/deploy/cloudapps/template.yaml
@@ -400,6 +400,16 @@ objects:
                     secretKeyRef:
                       name: ${APP_NAME}-secrets
                       key: SMTP_FROM
+                - name: SAML_SP_CERT
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-secrets
+                      key: SAML_SP_CERT
+                - name: SAML_SP_PRIVATE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-secrets
+                      key: SAML_SP_PRIVATE_KEY
               resources:
                 requests:
                   memory: ${BACKEND_MEMORY_REQUEST}

--- a/frontend/src/app/admin/login/page.tsx
+++ b/frontend/src/app/admin/login/page.tsx
@@ -3,9 +3,11 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { getMe, login } from "@/lib/admin-api";
+import { devLogin, getMe, samlLoginUrl } from "@/lib/admin-api";
 import { useRouter, useSearchParams } from "next/navigation";
 import { FormEvent, Suspense, useEffect, useState } from "react";
+
+const IS_DEV = process.env.NODE_ENV !== "production";
 
 function resolveNextPath(rawNext: string | null): string {
   if (!rawNext) {
@@ -23,14 +25,19 @@ function resolveNextPath(rawNext: string | null): string {
 function AdminLoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [onyen, setOnyen] = useState("");
-  const [password, setPassword] = useState("");
+  const [devOnyen, setDevOnyen] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCheckingSession, setIsCheckingSession] = useState(true);
   const redirectTarget = resolveNextPath(searchParams.get("next"));
 
-  const isFormValid = onyen.trim() !== "" && password !== "";
+  useEffect(() => {
+    if (searchParams.get("error") === "no_access") {
+      setError(
+        "Your UNC account signed in, but it isn't on the admin allowlist. Contact an admin to be added.",
+      );
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     let isMounted = true;
@@ -55,22 +62,28 @@ function AdminLoginContent() {
     };
   }, [redirectTarget, router]);
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const handleSsoLogin = () => {
+    const url = new URL(samlLoginUrl());
+    url.searchParams.set("next", redirectTarget);
+    window.location.href = url.toString();
+  };
+
+  const handleDevSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setError(null);
 
-    if (!isFormValid) {
-      setError("Please enter your Onyen and password.");
+    if (!devOnyen.trim()) {
+      setError("Please enter an Onyen.");
       return;
     }
 
     setIsSubmitting(true);
 
     try {
-      await login(onyen.trim(), password);
+      await devLogin(devOnyen.trim());
       router.replace(redirectTarget);
     } catch {
-      setError("Invalid credentials. Please check your Onyen and password.");
+      setError("No account found for that Onyen.");
     } finally {
       setIsSubmitting(false);
     }
@@ -90,61 +103,44 @@ function AdminLoginContent() {
         <p className="text-xs uppercase tracking-[0.2em] text-slate-500">UNC</p>
         <h1 className="mt-2 text-2xl font-bold text-slate-900">Admin Login</h1>
         <p className="mt-2 text-sm text-slate-600">
-          Sign in with your Onyen credentials to access the admin dashboard.
+          Sign in with your Onyen to access the admin dashboard.
         </p>
 
-        <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
-          <div className="space-y-1">
-            <label
-              className="text-sm font-medium text-slate-700"
-              htmlFor="onyen"
-            >
-              Onyen
-            </label>
-            <Input
-              id="onyen"
-              name="onyen"
-              type="text"
-              autoComplete="username"
-              value={onyen}
-              onChange={(event) => setOnyen(event.target.value)}
-              placeholder="onyen"
-              required
-            />
-          </div>
+        {error ? (
+          <p className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </p>
+        ) : null}
 
-          <div className="space-y-1">
-            <label
-              className="text-sm font-medium text-slate-700"
-              htmlFor="password"
-            >
-              Password
-            </label>
-            <Input
-              id="password"
-              name="password"
-              type="password"
-              autoComplete="current-password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              required
-            />
-          </div>
+        <Button className="mt-6 w-full" type="button" onClick={handleSsoLogin}>
+          Log in with Onyen
+        </Button>
 
-          {error ? (
-            <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-              {error}
+        {IS_DEV ? (
+          <div className="mt-6 border-t pt-6">
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+              Dev-only bypass
             </p>
-          ) : null}
-
-          <Button
-            className="w-full"
-            type="submit"
-            disabled={isSubmitting || !isFormValid}
-          >
-            {isSubmitting ? "Signing in..." : "Sign in"}
-          </Button>
-        </form>
+            <p className="mt-1 text-xs text-slate-500">
+              Not available in production. Logs in as any onyen already on the
+              accounts allowlist, no SSO round-trip required.
+            </p>
+            <form className="mt-3 flex gap-2" onSubmit={handleDevSubmit}>
+              <Input
+                id="dev-onyen"
+                name="dev-onyen"
+                type="text"
+                autoComplete="off"
+                value={devOnyen}
+                onChange={(event) => setDevOnyen(event.target.value)}
+                placeholder="onyen"
+              />
+              <Button type="submit" variant="outline" disabled={isSubmitting}>
+                {isSubmitting ? "Signing in..." : "Dev sign in"}
+              </Button>
+            </form>
+          </div>
+        ) : null}
       </Card>
     </section>
   );

--- a/frontend/src/app/admin/sso-callback/page.tsx
+++ b/frontend/src/app/admin/sso-callback/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { setToken } from "@/lib/token";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+function resolveNextPath(rawNext: string | null): string {
+  if (!rawNext) {
+    return "/admin";
+  }
+
+  // Prevent open redirects by only allowing internal admin paths.
+  if (!rawNext.startsWith("/admin") || rawNext.startsWith("/admin/login")) {
+    return "/admin";
+  }
+
+  return rawNext;
+}
+
+export default function SsoCallbackPage() {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const hash = new URLSearchParams(window.location.hash.slice(1));
+    const token = hash.get("token");
+
+    if (!token) {
+      setError("Sign-in did not complete. Please try again.");
+      return;
+    }
+
+    setToken(token);
+    router.replace(resolveNextPath(hash.get("next")));
+  }, [router]);
+
+  return (
+    <section className="grid min-h-screen place-items-center bg-slate-50 px-6">
+      <p className="text-sm text-slate-600">
+        {error ?? "Finishing sign-in..."}
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/components/admin/AccountForm.tsx
+++ b/frontend/src/components/admin/AccountForm.tsx
@@ -17,7 +17,6 @@ interface AccountFormProps {
   isLoading?: boolean;
 }
 
-const MIN_PASSWORD_LENGTH = 12;
 const ONYEN_PATTERN = /^[A-Za-z0-9._-]{2,64}$/;
 
 export function AccountForm({
@@ -30,14 +29,10 @@ export function AccountForm({
   const [lastName, setLastName] = useState(initialData?.last_name ?? "");
   const [email, setEmail] = useState(initialData?.email ?? "");
   const [onyen, setOnyen] = useState(initialData?.onyen ?? "");
-  const [password, setPassword] = useState("");
   const [role, setRole] = useState<"admin" | "staff">(
     initialData?.role ?? "staff",
   );
   const [onyenError, setOnyenError] = useState("");
-  const [passwordError, setPasswordError] = useState("");
-
-  const isEditing = Boolean(initialData);
 
   const handleOnyenChange = (value: string) => {
     setOnyen(value);
@@ -46,18 +41,6 @@ export function AccountForm({
     } else {
       setOnyenError("");
     }
-  };
-
-  const validatePassword = (value: string) => {
-    if ((!isEditing || value) && value.length < MIN_PASSWORD_LENGTH) {
-      return `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`;
-    }
-    return "";
-  };
-
-  const handlePasswordChange = (value: string) => {
-    setPassword(value);
-    setPasswordError(validatePassword(value));
   };
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -69,19 +52,12 @@ export function AccountForm({
       return;
     }
 
-    const nextPasswordError = validatePassword(password);
-    if (nextPasswordError) {
-      setPasswordError(nextPasswordError);
-      return;
-    }
-
     const payload = {
       first_name: firstName,
       last_name: lastName,
       email,
       onyen: trimmedOnyen,
       role,
-      ...(password ? { password } : {}),
     };
 
     onSubmit(payload as CreateAccount | UpdateAccount);
@@ -149,24 +125,6 @@ export function AccountForm({
           />
           {onyenError && (
             <p className="text-xs text-red-600 mt-1">{onyenError}</p>
-          )}
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Password
-          </label>
-          <input
-            required={!isEditing}
-            type="password"
-            autoComplete={isEditing ? "new-password" : "new-password"}
-            className={`w-full p-2 border rounded ${passwordError ? "border-red-500" : "border-gray-300"}`}
-            value={password}
-            onChange={(e) => handlePasswordChange(e.target.value)}
-            placeholder={isEditing ? "Leave blank to keep current password" : "12+ characters"}
-          />
-          {passwordError && (
-            <p className="text-xs text-red-600 mt-1">{passwordError}</p>
           )}
         </div>
 

--- a/frontend/src/lib/admin-api.ts
+++ b/frontend/src/lib/admin-api.ts
@@ -35,8 +35,8 @@ import type {
   CreateNews,
   CreateSenator,
   CreateStaff,
+  DevLoginCredentials,
   DistrictMapping,
-  LoginCredentials,
   LoginResponse,
   NavigationFlow,
   UpdateAccount,
@@ -180,12 +180,13 @@ export async function uploadAdminPdf(
 }
 
 // Auth
-export async function login(
-  onyen: string,
-  password: string,
-): Promise<LoginResponse> {
-  const body: LoginCredentials = { onyen, password };
-  const data = await request<LoginResponse>("/auth/login", {
+export function samlLoginUrl(): string {
+  return `${API_BASE}${buildApiPath("/auth/saml/login")}`;
+}
+
+export async function devLogin(onyen: string): Promise<LoginResponse> {
+  const body: DevLoginCredentials = { onyen };
+  const data = await request<LoginResponse>("/auth/dev-login", {
     method: "POST",
     body: JSON.stringify(body),
   });

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -1,6 +1,5 @@
-export interface LoginCredentials {
+export interface DevLoginCredentials {
   onyen: string;
-  password: string;
 }
 
 export interface LoginResponse {
@@ -216,7 +215,6 @@ export interface UpdateStaticPage {
 export interface CreateAccount {
   email: string;
   onyen: string;
-  password: string;
   first_name: string;
   last_name: string;
   role: "admin" | "staff";
@@ -225,7 +223,6 @@ export interface CreateAccount {
 export interface UpdateAccount {
   email: string;
   onyen: string;
-  password?: string;
   first_name: string;
   last_name: string;
   role: "admin" | "staff";


### PR DESCRIPTION
Admin login was a locally-stored onyen + password (`POST /api/auth/login`), despite the naming implying real UNC SSO. There was no onboarding flow (an admin typed a new user's password directly into the accounts form), no forgot-password recovery, and any admin could silently overwrite another admin's password with no ownership check.

Changes:

- Removed local password login entirely — `POST /api/auth/login` is gone, `Admin.password_hash` is now nullable, and the accounts tab (`AccountForm`, `/api/admin/accounts`) has no password field anymore. Creating/editing an account is now just "add this onyen to the allowlist with a role."
- Added real UNC Onyen SSO (SAML) — `GET /api/auth/saml/login` redirects to UNC's IdP with a signed AuthnRequest, `POST /api/auth/saml/acs` validates the response and matches the onyen against the allowlist. No auto-provisioning: an unknown onyen gets rejected, not created.
- IdP-side config (entity ID, SSO URL, signing cert) is wired against UNC ITS's actual metadata (`https://sso.unc.edu/metadata/idp`), verified directly rather than trusted from a paste. SP-side credentials (`sp.crt`/`sp.key`) are read from env vars sourced from the OpenShift secret and are intentionally unset until that secret is provisioned — SSO returns 503 until then.
- Added a dev-only login bypass (`POST /api/auth/dev-login`, disabled when `ENVIRONMENT=production`) so local development doesn't depend on a live SSO round-trip.
- `init_db.py` now also relaxes NOT NULL constraints on columns that became nullable (previously it only added missing columns), so the `password_hash` change applies cleanly to the already-deployed database.
- Updated seed data to two accounts (calebhan, mmines), both admin, no password.
- Deferred to a follow-up: moving the auth token out of `localStorage` into an httpOnly cookie.

Closes #220